### PR TITLE
Add npm release automation

### DIFF
--- a/.github/workflows/release-preview.yml
+++ b/.github/workflows/release-preview.yml
@@ -1,0 +1,18 @@
+name: Release Preview
+
+on:
+  workflow_dispatch:
+
+jobs:
+  publish-dry-run:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: lts/*
+          registry-url: https://registry.npmjs.org
+          cache: npm
+      - run: npm install
+      - run: npm run build
+      - run: npm publish --dry-run

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,25 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*"
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: lts/*
+          registry-url: https://registry.npmjs.org
+          cache: npm
+      - run: npm install
+      - run: npm run build
+      - run: npm publish --provenance --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+engine-strict=true

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Christian Anagnostou
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ Local-first, agent-agnostic skills manager. Track, update, and sync skills acros
 npm install -g skillbox
 ```
 
+TODO: Publish initial npm release
+
 ### From Source
 
 ```bash

--- a/docs/npm-release.md
+++ b/docs/npm-release.md
@@ -1,0 +1,35 @@
+# NPM Release Guide
+
+This repo publishes the CLI to npm using GitHub Actions.
+
+## One-time setup
+
+1) Create an npm access token with publish permissions.
+2) Add it to GitHub Actions secrets as `NPM_TOKEN`.
+3) Confirm the package name `skillbox` is available in npm.
+
+## Release flow
+
+1) Update version in `package.json`.
+2) Build locally and run checks:
+
+```bash
+npm run lint:ci
+npm run format:check
+npm run build
+```
+
+3) Tag and push:
+
+```bash
+git tag v0.1.0
+git push origin v0.1.0
+```
+
+4) GitHub Actions publishes to npm.
+
+## Dry run
+
+Trigger the `Release Preview` workflow and verify the publish output.
+
+TODO: Add a release checklist and changelog workflow.

--- a/package.json
+++ b/package.json
@@ -5,17 +5,35 @@
   "license": "MIT",
   "author": "Christian Anagnostou",
   "type": "module",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/christiananagnostou/skillbox.git"
+  },
+  "homepage": "https://github.com/christiananagnostou/skillbox",
+  "bugs": {
+    "url": "https://github.com/christiananagnostou/skillbox/issues"
+  },
+  "engines": {
+    "node": ">=20"
+  },
   "bin": {
     "skillbox": "dist/cli.js"
   },
+  "files": [
+    "dist",
+    "README.md",
+    "LICENSE"
+  ],
   "scripts": {
     "build": "tsc -p tsconfig.json",
     "dev": "ts-node-esm src/cli.ts",
+    "prepare": "npm run build",
     "lint": "oxlint",
     "lint:fix": "oxlint --fix",
     "lint:ci": "oxlint --deny-warnings",
     "format": "oxfmt",
-    "format:check": "oxfmt --check"
+    "format:check": "oxfmt --check",
+    "prepublishOnly": "npm run lint:ci && npm run format:check && npm run build"
   },
   "dependencies": {
     "chalk": "^5.3.0",


### PR DESCRIPTION
## Summary
- add npm release workflows (tag publish + dry-run)
- add package metadata/engines/files and prepublish checks
- add npm release guide, MIT license, and npm TODOs