### PR TITLE
fix: respect defaultAgents config in discovery commands

### DIFF
--- a/src/lib/agents.ts
+++ b/src/lib/agents.ts
@@ -53,6 +53,33 @@ export const getUserAgentPaths = (projectRoot: string): string[] => {
   return Object.values(paths).flatMap((entry) => entry.user);
 };
 
+export type AgentPath = {
+  agent: AgentId;
+  path: string;
+};
+
+export const getUserPathsForAgents = (projectRoot: string, agents: AgentId[]): AgentPath[] => {
+  const paths = agentPaths(projectRoot);
+  const seen = new Set<string>();
+  const results: AgentPath[] = [];
+
+  for (const agent of agents) {
+    const agentEntry = paths[agent];
+    if (!agentEntry) {
+      continue;
+    }
+    for (const userPath of agentEntry.user) {
+      if (seen.has(userPath)) {
+        continue;
+      }
+      seen.add(userPath);
+      results.push({ agent, path: userPath });
+    }
+  }
+
+  return results;
+};
+
 const agentSet = new Set(allAgents);
 
 export const isAgentId = (value: string): value is AgentId => {

--- a/src/lib/global-skills.ts
+++ b/src/lib/global-skills.ts
@@ -1,23 +1,36 @@
-import { getUserAgentPaths } from "./agents.js";
+import type { AgentId } from "./agents.js";
+import { getUserPathsForAgents } from "./agents.js";
 import { discoverSkills } from "./discovery.js";
 
 export type GlobalSkill = {
   name: string;
-  installs: Array<{ scope: "user"; agent: string; path: string }>;
+  installs: Array<{ scope: "user"; agent: AgentId; path: string }>;
 };
 
-export const discoverGlobalSkills = async (projectRoot: string): Promise<GlobalSkill[]> => {
-  const userPaths = getUserAgentPaths(projectRoot);
-  const userSkills = await discoverSkills(userPaths);
+export const discoverGlobalSkills = async (
+  projectRoot: string,
+  agents: AgentId[]
+): Promise<GlobalSkill[]> => {
+  const agentPaths = getUserPathsForAgents(projectRoot, agents);
+  const skillMap = new Map<string, GlobalSkill>();
 
-  return userSkills.map((skill) => ({
-    name: skill.name,
-    installs: [
-      {
-        scope: "user",
-        agent: "unknown",
-        path: skill.skillDir,
-      },
-    ],
-  }));
+  for (const { agent, path: agentPath } of agentPaths) {
+    const discovered = await discoverSkills([agentPath]);
+    for (const skill of discovered) {
+      const existing = skillMap.get(skill.name);
+      if (existing) {
+        const alreadyHasPath = existing.installs.some((i) => i.path === skill.skillDir);
+        if (!alreadyHasPath) {
+          existing.installs.push({ scope: "user", agent, path: skill.skillDir });
+        }
+      } else {
+        skillMap.set(skill.name, {
+          name: skill.name,
+          installs: [{ scope: "user", agent, path: skill.skillDir }],
+        });
+      }
+    }
+  }
+
+  return Array.from(skillMap.values());
 };


### PR DESCRIPTION
## Summary
- Fix `list` and `import --global` commands ignoring `defaultAgents` config
- Skills were appearing duplicated (e.g., 20 instead of 5) because shared paths like `~/.claude/skills` were scanned multiple times for each agent
- Now correctly tracks which agent found each skill instead of showing "unknown"

## Test plan
- [ ] Run `skillbox config get` to verify `defaultAgents` is set
- [ ] Run `skillbox list` and confirm no duplicates
- [ ] Run `skillbox list --json` and verify `agent` field shows correct agent name
- [ ] Run `skillbox import --global --json` and verify it respects config