### PR TITLE
feat: improve CLI output formatting and onboarding UX

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -66,7 +66,7 @@ Examples:
 Behavior:
 
 - Uses the GitHub tree API to discover skills.
-- Requires --skill or --yes when multiple skills are found.
+- Installs all discovered skills by default, or use --skill to select specific ones.
 - Downloads the full skill directory into the canonical store (not just SKILL.md).
 - Tracks repo metadata so `skillbox update` refreshes from the repo.
 - Note: GitHub unauthenticated API limits are 60 requests per hour per IP, so heavy repo usage may hit rate limits.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "skillbox",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "skillbox",
-      "version": "0.2.1",
+      "version": "0.2.2",
       "license": "MIT",
       "dependencies": {
         "chalk": "^5.3.0",

--- a/src/commands/add-repo.ts
+++ b/src/commands/add-repo.ts
@@ -108,9 +108,11 @@ export async function handleRepoInstall(input: string, options: RepoAddOptions):
       printJson({ ok: true, command: "add", data: { repo: input, skills: skillNames } });
       return;
     }
-    printInfo(`Skills found: ${skillNames.length}`);
+    printInfo(`Repo Skills: ${ref.owner}/${ref.repo}`);
+    printInfo("");
+    printInfo(`Found ${skillNames.length} skill(s):`);
     for (const name of skillNames) {
-      printInfo(`- ${name}`);
+      printInfo(`  - ${name}`);
     }
     return;
   }
@@ -186,26 +188,50 @@ export async function handleRepoInstall(input: string, options: RepoAddOptions):
   await saveIndex(sortIndex(index));
 
   if (options.json) {
-    printJson({ ok: true, command: "add", data: summary });
+    printJson({ ok: true, command: "add", data: { repo: `${ref.owner}/${ref.repo}`, ...summary } });
     return;
   }
 
-  if (summary.failed.length > 0) {
-    printInfo("Some skills failed to install:");
-    for (const failure of summary.failed) {
-      printInfo(`- ${failure.name}: ${failure.reason}`);
+  printInfo(`Skills Added from: ${ref.owner}/${ref.repo}`);
+  printInfo("");
+  printInfo("Source: git");
+  printInfo(`  ${ref.owner}/${ref.repo}${ref.path ? `/${ref.path}` : ""} (${ref.ref})`);
+
+  if (summary.installed.length > 0) {
+    printInfo("");
+    printInfo(`Installed (${summary.installed.length}):`);
+    for (const name of summary.installed) {
+      printInfo(`  ✓ ${name}`);
     }
   }
-  if (summary.installed.length > 0) {
-    printInfo(`Installed ${summary.installed.length} skill(s): ${summary.installed.join(", ")}`);
-  }
+
   if (summary.updated.length > 0) {
-    printInfo(`Updated ${summary.updated.length} skill(s): ${summary.updated.join(", ")}`);
+    printInfo("");
+    printInfo(`Updated (${summary.updated.length}):`);
+    for (const name of summary.updated) {
+      printInfo(`  ✓ ${name}`);
+    }
   }
+
   if (summary.skipped.length > 0) {
-    printInfo(`Skipped ${summary.skipped.length} skill(s): ${summary.skipped.join(", ")}`);
+    printInfo("");
+    printInfo(`Skipped (${summary.skipped.length}):`);
+    for (const name of summary.skipped) {
+      printInfo(`  - ${name} (missing description)`);
+    }
   }
-  if (summary.installed.length === 0 && summary.updated.length === 0) {
-    printInfo("No agent targets were updated (canonical store only).");
+
+  if (summary.failed.length > 0) {
+    printInfo("");
+    printInfo(`Failed (${summary.failed.length}):`);
+    for (const failure of summary.failed) {
+      printInfo(`  ✗ ${failure.name} (${failure.reason})`);
+    }
+  }
+
+  const total = summary.installed.length + summary.updated.length;
+  if (total === 0) {
+    printInfo("");
+    printInfo("No skills were added.");
   }
 }

--- a/src/commands/add.ts
+++ b/src/commands/add.ts
@@ -124,20 +124,32 @@ export function registerAdd(program: Command): void {
           printJson({
             ok: true,
             command: "add",
-            data: { name: skillName, url, scope, agents: installed },
+            data: {
+              name: skillName,
+              source: { type: "url", url },
+              scope,
+              installs,
+            },
           });
           return;
         }
 
-        printInfo(`Installed skill: ${skillName}`);
-        printInfo(`Source: ${url}`);
-        printInfo(`Scope: ${scope}`);
-        if (installed.length === 0) {
-          printInfo("No agent targets were updated (canonical store only).");
-        } else {
-          for (const entry of installed) {
-            printInfo(`Updated ${entry.agent}: ${entry.targets.join(", ")}`);
+        printInfo(`Skill Added: ${skillName}`);
+        printInfo("");
+        printInfo("Source: url");
+        printInfo(`  ${url}`);
+
+        if (installs.length > 0) {
+          printInfo("");
+          printInfo("Installed to:");
+          for (const install of installs) {
+            const scopeLabel =
+              install.scope === "project" ? `project:${install.projectRoot}` : "user";
+            printInfo(`  ✓ ${scopeLabel}/${install.agent}`);
           }
+        } else {
+          printInfo("");
+          printInfo("No agent targets were updated.");
         }
       } catch (error) {
         handleCommandError(options, "add", error);

--- a/src/commands/status.ts
+++ b/src/commands/status.ts
@@ -1,154 +1,177 @@
 import type { Command } from "commander";
 import { handleCommandError } from "../lib/command.js";
 import { fetchText } from "../lib/fetcher.js";
-import { groupStatusByKey } from "../lib/grouping.js";
 import { loadIndex, saveIndex } from "../lib/index.js";
-import { isJsonEnabled, printInfo, printJson, printList } from "../lib/output.js";
+import { isJsonEnabled, printInfo, printJson } from "../lib/output.js";
 import { hashContent } from "../lib/skill-store.js";
+import { groupAndSort, sortByName } from "../lib/source-grouping.js";
 
-type StatusResult = {
+type SkillStatus = {
   name: string;
   source: string;
+  trackable: boolean;
   outdated: boolean;
   localChecksum: string;
   remoteChecksum?: string;
-  projects: string[];
+  error?: string;
 };
 
-function groupByProject(results: StatusResult[]): Array<{
-  root: string;
-  outdated: string[];
-  upToDate: string[];
-}> {
-  const grouped = groupStatusByKey(
-    results,
-    (result) => result.name,
-    (result) => result.outdated,
-    (result) => result.projects
-  );
-  return grouped.map((group) => ({
-    root: group.key,
-    outdated: group.outdated,
-    upToDate: group.upToDate,
-  }));
+type SourceGroup = {
+  source: string;
+  skills: SkillStatus[];
+  trackable: boolean;
+  outdatedCount: number;
+  upToDateCount: number;
+};
+
+async function checkSkillStatus(skill: {
+  name: string;
+  source: { type: string; url?: string };
+  checksum: string;
+}): Promise<SkillStatus> {
+  const isTrackable = skill.source.type === "url" || skill.source.type === "git";
+
+  if (!isTrackable || skill.source.type !== "url" || !skill.source.url) {
+    return {
+      name: skill.name,
+      source: skill.source.type,
+      trackable: isTrackable,
+      outdated: false,
+      localChecksum: skill.checksum,
+    };
+  }
+
+  try {
+    const remoteText = await fetchText(skill.source.url);
+    const remoteChecksum = hashContent(remoteText);
+    const outdated = remoteChecksum !== skill.checksum;
+
+    return {
+      name: skill.name,
+      source: skill.source.type,
+      trackable: true,
+      outdated,
+      localChecksum: skill.checksum,
+      remoteChecksum,
+    };
+  } catch (err) {
+    return {
+      name: skill.name,
+      source: skill.source.type,
+      trackable: true,
+      outdated: false,
+      localChecksum: skill.checksum,
+      error: err instanceof Error ? err.message : "Failed to check",
+    };
+  }
 }
 
-function groupBySource(results: StatusResult[]): Array<{
-  source: string;
-  outdated: string[];
-  upToDate: string[];
-}> {
-  const grouped = groupStatusByKey(
-    results,
-    (result) => result.name,
-    (result) => result.outdated,
-    (result) => [result.source]
-  );
-  return grouped.map((group) => ({
-    source: group.key,
-    outdated: group.outdated,
-    upToDate: group.upToDate,
-  }));
+// Sort sources: url first, then git, then local (for status command - trackable first)
+const STATUS_SOURCE_ORDER = ["url", "git", "local"];
+
+function groupBySource(statuses: SkillStatus[]): SourceGroup[] {
+  const grouped = groupAndSort(statuses, (s) => s.source, STATUS_SOURCE_ORDER, sortByName);
+
+  return grouped.map(({ key, items }) => {
+    const trackable = items.some((s) => s.trackable);
+    const outdatedCount = items.filter((s) => s.outdated).length;
+    const upToDateCount = items.filter((s) => s.trackable && !s.outdated && !s.error).length;
+
+    return {
+      source: key,
+      skills: items,
+      trackable,
+      outdatedCount,
+      upToDateCount,
+    };
+  });
+}
+
+function formatSourceHeader(group: SourceGroup): string {
+  const count = group.skills.length;
+  const skillWord = count === 1 ? "skill" : "skills";
+
+  if (!group.trackable) {
+    return `${group.source} (${count} ${skillWord} - not tracked)`;
+  }
+
+  if (group.outdatedCount > 0) {
+    return `${group.source} (${count} ${skillWord}, ${group.outdatedCount} outdated)`;
+  }
+
+  return `${group.source} (${count} ${skillWord})`;
+}
+
+function printSourceGroup(group: SourceGroup): void {
+  printInfo(formatSourceHeader(group));
+
+  for (const skill of group.skills) {
+    if (!group.trackable) {
+      printInfo(`  ${skill.name}`);
+    } else if (skill.error) {
+      printInfo(`  ? ${skill.name} (${skill.error})`);
+    } else if (skill.outdated) {
+      printInfo(`  ✗ ${skill.name} (outdated)`);
+    } else {
+      printInfo(`  ✓ ${skill.name}`);
+    }
+  }
 }
 
 export function registerStatus(program: Command): void {
   program
     .command("status")
-    .option("--group <group>", "Group by project or source")
     .option("--json", "JSON output")
     .action(async (options) => {
       try {
         const index = await loadIndex();
-        const results: StatusResult[] = [];
+        const statuses: SkillStatus[] = [];
 
         for (const skill of index.skills) {
-          const projects = Array.from(
-            new Set(
-              (skill.installs ?? [])
-                .filter((install) => install.scope === "project" && install.projectRoot)
-                .map((install) => install.projectRoot as string)
-            )
-          );
+          const status = await checkSkillStatus(skill);
+          statuses.push(status);
 
-          if (skill.source.type !== "url" || !skill.source.url) {
-            results.push({
-              name: skill.name,
-              source: skill.source.type,
-              outdated: false,
-              localChecksum: skill.checksum,
-              projects,
-            });
-            continue;
+          // Update lastChecked for trackable skills
+          if (status.trackable && !status.error) {
+            skill.lastChecked = new Date().toISOString();
           }
-
-          const remoteText = await fetchText(skill.source.url);
-          const remoteChecksum = hashContent(remoteText);
-          const outdated = remoteChecksum !== skill.checksum;
-          skill.lastChecked = new Date().toISOString();
-
-          results.push({
-            name: skill.name,
-            source: skill.source.type,
-            outdated,
-            localChecksum: skill.checksum,
-            remoteChecksum,
-            projects,
-          });
         }
 
         await saveIndex(index);
 
-        const outdated = results.filter((entry) => entry.outdated).map((entry) => entry.name);
-        const upToDate = results.filter((entry) => !entry.outdated).map((entry) => entry.name);
-        const groupedProjects = groupByProject(results);
-        const groupedSources = groupBySource(results);
+        const sourceGroups = groupBySource(statuses);
+        const totalOutdated = statuses.filter((s) => s.outdated).length;
+        const totalTrackable = statuses.filter((s) => s.trackable).length;
+        const totalUpToDate = statuses.filter((s) => s.trackable && !s.outdated && !s.error).length;
 
         if (isJsonEnabled(options)) {
           printJson({
             ok: true,
             command: "status",
             data: {
-              group: options.group ?? null,
-              outdated,
-              upToDate,
-              results,
-              projects: options.group === "project" ? groupedProjects : undefined,
-              sources: options.group === "source" ? groupedSources : undefined,
+              total: statuses.length,
+              outdated: totalOutdated,
+              upToDate: totalUpToDate,
+              trackable: totalTrackable,
+              skills: statuses,
+              bySource: sourceGroups,
             },
           });
           return;
         }
 
-        if (options.group === "project") {
-          printInfo(`Projects: ${groupedProjects.length}`);
-          for (const project of groupedProjects) {
-            printInfo(`- ${project.root}`);
-            if (project.outdated.length > 0) {
-              printList("  Outdated", project.outdated, "    - ");
-            }
-            if (project.upToDate.length > 0) {
-              printList("  Up to date", project.upToDate, "    - ");
-            }
-          }
-          return;
+        printInfo("Skill Status");
+
+        for (const group of sourceGroups) {
+          printInfo("");
+          printSourceGroup(group);
         }
 
-        if (options.group === "source") {
-          printInfo(`Sources: ${groupedSources.length}`);
-          for (const source of groupedSources) {
-            printInfo(`- ${source.source}`);
-            if (source.outdated.length > 0) {
-              printList("  Outdated", source.outdated, "    - ");
-            }
-            if (source.upToDate.length > 0) {
-              printList("  Up to date", source.upToDate, "    - ");
-            }
-          }
-          return;
+        // Summary line if there are outdated skills
+        if (totalOutdated > 0) {
+          printInfo("");
+          printInfo(`Run 'skillbox update' to update ${totalOutdated} outdated skill(s).`);
         }
-
-        printList("Outdated", outdated);
-        printList("Up to date", upToDate);
       } catch (error) {
         handleCommandError(options, "status", error);
       }

--- a/src/commands/update.ts
+++ b/src/commands/update.ts
@@ -9,8 +9,66 @@ import { isJsonEnabled, printInfo, printJson } from "../lib/output.js";
 import { fetchRepoFile, normalizeRepoRef, writeRepoSkillDirectory } from "../lib/repo-skills.js";
 import { buildMetadata, parseSkillMarkdown } from "../lib/skill-parser.js";
 import { ensureSkillsDir, writeSkillFiles, writeSkillMetadata } from "../lib/skill-store.js";
+import { groupAndSort, sortByName } from "../lib/source-grouping.js";
 import { installSkillToTargets } from "../lib/sync.js";
 import type { IndexedSkill, SkillIndex } from "../lib/types.js";
+
+type UpdateResult = {
+  name: string;
+  source: string;
+  status: "updated" | "failed" | "skipped";
+  error?: string;
+};
+
+type SourceGroup = {
+  source: string;
+  results: UpdateResult[];
+  updatedCount: number;
+  failedCount: number;
+};
+
+// Sort sources: url first, then git (trackable sources first)
+const UPDATE_SOURCE_ORDER = ["url", "git", "local"];
+
+function groupBySource(results: UpdateResult[]): SourceGroup[] {
+  const grouped = groupAndSort(results, (r) => r.source, UPDATE_SOURCE_ORDER, sortByName);
+
+  return grouped.map(({ key, items }) => ({
+    source: key,
+    results: items,
+    updatedCount: items.filter((r) => r.status === "updated").length,
+    failedCount: items.filter((r) => r.status === "failed").length,
+  }));
+}
+
+function formatSourceHeader(group: SourceGroup): string {
+  const count = group.results.length;
+  const skillWord = count === 1 ? "skill" : "skills";
+
+  if (group.source === "local") {
+    return `${group.source} (${count} ${skillWord} - skipped)`;
+  }
+
+  if (group.failedCount > 0) {
+    return `${group.source} (${count} ${skillWord}, ${group.failedCount} failed)`;
+  }
+
+  return `${group.source} (${count} ${skillWord})`;
+}
+
+function printSourceGroup(group: SourceGroup): void {
+  printInfo(formatSourceHeader(group));
+
+  for (const result of group.results) {
+    if (result.status === "skipped") {
+      printInfo(`  - ${result.name}`);
+    } else if (result.status === "failed") {
+      printInfo(`  ✗ ${result.name} (${result.error ?? "failed"})`);
+    } else {
+      printInfo(`  ✓ ${result.name}`);
+    }
+  }
+}
 
 async function updateUrlSkill(
   skill: IndexedSkill,
@@ -117,41 +175,90 @@ export function registerUpdate(program: Command): void {
           throw new Error(`Skill not found: ${name}`);
         }
 
-        const updated: string[] = [];
         await ensureSkillsDir();
 
         const config = await loadConfig();
         const projectRoot = options.project ? path.resolve(options.project) : null;
+        const results: UpdateResult[] = [];
 
         for (const skill of targets) {
           if (skill.source.type === "url") {
-            await updateUrlSkill(skill, index, projectRoot, config);
-            updated.push(skill.name);
+            try {
+              await updateUrlSkill(skill, index, projectRoot, config);
+              results.push({ name: skill.name, source: "url", status: "updated" });
+            } catch (err) {
+              results.push({
+                name: skill.name,
+                source: "url",
+                status: "failed",
+                error: err instanceof Error ? err.message : "unknown error",
+              });
+            }
           } else if (skill.source.type === "git") {
-            await updateGitSkill(skill, index, projectRoot, config);
-            updated.push(skill.name);
+            try {
+              await updateGitSkill(skill, index, projectRoot, config);
+              results.push({ name: skill.name, source: "git", status: "updated" });
+            } catch (err) {
+              results.push({
+                name: skill.name,
+                source: "git",
+                status: "failed",
+                error: err instanceof Error ? err.message : "unknown error",
+              });
+            }
+          } else {
+            results.push({ name: skill.name, source: skill.source.type, status: "skipped" });
           }
         }
 
         await saveIndex(sortIndex(index));
 
+        const sourceGroups = groupBySource(results);
+        const totalUpdated = results.filter((r) => r.status === "updated").length;
+        const totalFailed = results.filter((r) => r.status === "failed").length;
+        const totalSkipped = results.filter((r) => r.status === "skipped").length;
+        const totalTrackable = results.filter((r) => r.source !== "local").length;
+
         if (isJsonEnabled(options)) {
           printJson({
             ok: true,
             command: "update",
-            data: { name: name ?? null, project: projectRoot, updated },
+            data: {
+              name: name ?? null,
+              project: projectRoot,
+              total: results.length,
+              updated: totalUpdated,
+              failed: totalFailed,
+              skipped: totalSkipped,
+              results,
+              bySource: sourceGroups,
+            },
           });
           return;
         }
 
-        if (updated.length === 0) {
-          printInfo("No skills updated.");
+        if (results.length === 0) {
+          printInfo("No skills to update.");
           return;
         }
 
-        printInfo(`Updated ${updated.length} skill(s):`);
-        for (const skillName of updated) {
-          printInfo(`- ${skillName}`);
+        printInfo("Skill Update");
+
+        for (const group of sourceGroups) {
+          printInfo("");
+          printSourceGroup(group);
+        }
+
+        // Summary line
+        printInfo("");
+        if (totalFailed > 0) {
+          printInfo(
+            `Updated ${totalUpdated} of ${totalTrackable} trackable skills (${totalFailed} failed).`
+          );
+        } else if (totalUpdated > 0) {
+          printInfo(`Updated ${totalUpdated} of ${totalTrackable} trackable skills.`);
+        } else if (totalSkipped > 0 && totalTrackable === 0) {
+          printInfo("No trackable skills to update.");
         }
       } catch (error) {
         handleCommandError(options, "update", error);

--- a/src/lib/onboarding.ts
+++ b/src/lib/onboarding.ts
@@ -1,34 +1,30 @@
-import { stdin as input, stdout as output } from "node:process";
-import readline from "node:readline/promises";
 import { detectAgents } from "./agent-detect.js";
-import { allAgents, isAgentId } from "./agents.js";
+import { allAgents } from "./agents.js";
 import { loadConfig, saveConfig } from "./config.js";
+import { printInfo } from "./output.js";
 
-function formatPrompt(detected: string[]): string {
-  if (detected.length === 0) {
-    return `Which agents do you use? (comma-separated) [${allAgents.join(", ")}]: `;
-  }
-  return `Detected agents: ${detected.join(", ")}. Press enter to accept or edit: `;
+function printWelcome(): void {
+  printInfo("");
+  printInfo("Welcome to Skillbox");
+  printInfo("Local-first, agent-agnostic skills manager");
+  printInfo("");
 }
 
-async function promptAgents(): Promise<string[]> {
-  const detected = await detectAgents();
-  const rl = readline.createInterface({ input, output });
-  const answer = await rl.question(formatPrompt(detected));
-  rl.close();
-
-  const raw = answer.trim().length > 0 ? answer : detected.join(",");
-  const selected = raw
-    .split(",")
-    .map((agent) => agent.trim())
-    .filter((agent) => agent.length > 0)
-    .filter(isAgentId);
-
-  if (selected.length > 0) {
-    return selected;
+function printDetectedAgents(agents: string[]): void {
+  if (agents.length === 0) {
+    printInfo("No agents detected. Using all supported agents:");
+    for (const agent of allAgents) {
+      printInfo(`  - ${agent}`);
+    }
+  } else {
+    printInfo("Detected agents:");
+    for (const agent of agents) {
+      printInfo(`  ✓ ${agent}`);
+    }
   }
-
-  return detected.length > 0 ? detected : allAgents;
+  printInfo("");
+  printInfo("Run 'skillbox config set --add-agent <name>' to add more agents.");
+  printInfo("");
 }
 
 export async function runOnboarding(): Promise<void> {
@@ -37,6 +33,11 @@ export async function runOnboarding(): Promise<void> {
     return;
   }
 
-  const selected = await promptAgents();
+  const detected = await detectAgents();
+  const selected = detected.length > 0 ? detected : allAgents;
+
+  printWelcome();
+  printDetectedAgents(detected);
+
   await saveConfig({ ...config, defaultAgents: selected });
 }

--- a/src/lib/source-grouping.ts
+++ b/src/lib/source-grouping.ts
@@ -1,0 +1,58 @@
+/**
+ * Shared utilities for grouping items by source type.
+ */
+
+/**
+ * Groups items by a key into a Map.
+ */
+export function groupByKey<T>(items: T[], getKey: (item: T) => string): Map<string, T[]> {
+  const groups = new Map<string, T[]>();
+
+  for (const item of items) {
+    const key = getKey(item);
+    const existing = groups.get(key) ?? [];
+    existing.push(item);
+    groups.set(key, existing);
+  }
+
+  return groups;
+}
+
+/**
+ * Sorts group keys according to a predefined order, with unknown keys sorted alphabetically at the end.
+ */
+export function sortGroupKeys(keys: string[], keyOrder: string[]): string[] {
+  return [...keys].sort((a, b) => {
+    const aIndex = keyOrder.indexOf(a);
+    const bIndex = keyOrder.indexOf(b);
+    if (aIndex !== -1 && bIndex !== -1) return aIndex - bIndex;
+    if (aIndex !== -1) return -1;
+    if (bIndex !== -1) return 1;
+    return a.localeCompare(b);
+  });
+}
+
+/**
+ * Groups items by a key, sorts groups by a predefined order, and sorts items within each group.
+ */
+export function groupAndSort<T>(
+  items: T[],
+  getKey: (item: T) => string,
+  keyOrder: string[],
+  sortItems: (a: T, b: T) => number
+): Array<{ key: string; items: T[] }> {
+  const groups = groupByKey(items, getKey);
+  const sortedKeys = sortGroupKeys(Array.from(groups.keys()), keyOrder);
+
+  return sortedKeys.map((key) => ({
+    key,
+    items: (groups.get(key) ?? []).sort(sortItems),
+  }));
+}
+
+/**
+ * Default sort function for items with a name property.
+ */
+export function sortByName<T extends { name: string }>(a: T, b: T): number {
+  return a.name.localeCompare(b.name);
+}


### PR DESCRIPTION
## Summary

- Adds consistent, structured output formatting across all major CLI commands
- Improves onboarding to auto-detect agents without blocking prompts (AI-agent friendly)
- Extracts shared source-grouping logic into a reusable utility

## Changes

### New formatting for commands

**list** - Groups by scope (global/project) and source type, shows subcommands
```
Global Skills (8)

local
  agent-browser
  clean-code
    → debug, duplicates, slop, unused
  create-pr
    → diagrams, template

url
  react-best-practices
  vercel-deploy-claimable
```

**status** - Shows trackable status with checkmarks
```
Skill Status

url (3 skills)
  ✓ react-best-practices
  ✓ vercel-deploy-claimable
  ✓ web-design-guidelines

local (5 skills - not tracked)
  agent-browser
  clean-code
```

**update** - Shows progress with success/failure indicators
```
Skill Update

url (3 skills)
  ✓ react-best-practices
  ✓ vercel-deploy-claimable
  ✓ web-design-guidelines

local (5 skills - skipped)
  - agent-browser
  - clean-code

Updated 3 of 3 trackable skills.
```

**add/remove** - Consistent mirrored output
```
Skill Added: react-best-practices

Source: url
  https://raw.githubusercontent.com/...

Installed to:
  ✓ user/claude
```

### Onboarding improvements

- Removes interactive prompts that blocked AI agents
- Auto-detects installed agents and proceeds
- Adds welcome banner with detected agents display

```
Welcome to Skillbox
Local-first, agent-agnostic skills manager

Detected agents:
  ✓ claude

Run 'skillbox config set --add-agent <name>' to add more agents.
```

## Test plan

- [x] Run `skillbox list` and verify grouped output
- [x] Run `skillbox status` and verify checkmarks
- [x] Run `skillbox update` and verify progress display
- [x] Run `skillbox add <url>` and verify new format
- [x] Run `skillbox remove <name>` and verify mirrored format
- [x] Delete config and run any command to verify onboarding
- [x] Verify JSON output still works for all commands

🤖 Generated with [Claude Code](https://claude.com/claude-code)