### PR TITLE
chore: bump version to 0.3.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "skillbox",
-  "version": "0.2.2",
+  "version": "0.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "skillbox",
-      "version": "0.2.2",
+      "version": "0.3.0",
       "license": "MIT",
       "dependencies": {
         "chalk": "^5.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "skillbox",
-  "version": "0.2.2",
+  "version": "0.3.0",
   "description": "Local-first, agent-agnostic skills manager",
   "license": "MIT",
   "author": "Christian Anagnostou",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -14,7 +14,7 @@ import { registerUpdate } from "./commands/update.js";
 
 const program = new Command();
 
-program.name("skillbox").description("Local-first, agent-agnostic skills manager").version("0.2.2");
+program.name("skillbox").description("Local-first, agent-agnostic skills manager").version("0.3.0");
 
 registerAdd(program);
 registerAgent(program);


### PR DESCRIPTION
## Summary

Bumps version to 0.3.0 for new release.

## Changes

Updates version in:
- `package.json`
- `package-lock.json`
- `src/cli.ts`

## Release notes

Since 0.2.2:
- Improved CLI output formatting across all commands
- Fixed onboarding to auto-detect agents without blocking prompts
- Fixed `--agents` flag to properly filter skills in list command
- Updated README with tables and golden workflow
- Added `skills/skillbox/SKILL.md` for agent onboarding