### PR TITLE
fix: improve symlink warning messages

### DIFF
--- a/src/commands/add-repo.ts
+++ b/src/commands/add-repo.ts
@@ -77,8 +77,8 @@ async function installSkillTargets(
       .filter((result) => result.mode !== "skipped")
       .map((result) => result.path);
 
-    const warning = buildSymlinkWarning(agent, results);
-    if (warning) {
+    const warnings = buildSymlinkWarning(agent, results);
+    for (const warning of warnings) {
       printInfo(warning);
     }
 

--- a/src/commands/add.ts
+++ b/src/commands/add.ts
@@ -94,8 +94,8 @@ export function registerAdd(program: Command): void {
           const written = results
             .filter((result) => result.mode !== "skipped")
             .map((result) => result.path);
-          const warning = buildSymlinkWarning(agent, results);
-          if (warning) {
+          const warnings = buildSymlinkWarning(agent, results);
+          for (const warning of warnings) {
             printInfo(warning);
           }
           if (written.length > 0) {


### PR DESCRIPTION
## Summary

- Skip warning when symlink already points to the correct location
- Clean up warning format to be more readable

## Before

```
Warning: symlink failed for claude. /Users/christian.anagnostou/.claude/skills/clean-code: EEXIST: file already exists, symlink '/Users/christian.anagnostou/.config/skillbox/skills/clean-code' -> '/Users/christian.anagnostou/.claude/skills/clean-code'. Remove the existing target or run "skillbox config set --install-mode copy" to use file copies.
```

## After

When symlink already exists and points to correct location: **no warning**

When there's an actual conflict:
```
  ⚠ clean-code (claude): already exists at target, remove manually or use --install-mode copy
```

## Test plan

- [x] Reinstalling skills with existing valid symlinks shows no warnings
- [x] Reinstalling skills with conflicting paths shows clean warning