### PR TITLE
chore: bump version to 0.3.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "skillbox",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "skillbox",
-      "version": "0.3.0",
+      "version": "0.3.1",
       "license": "MIT",
       "dependencies": {
         "chalk": "^5.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "skillbox",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Local-first, agent-agnostic skills manager",
   "license": "MIT",
   "author": "Christian Anagnostou",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -14,7 +14,7 @@ import { registerUpdate } from "./commands/update.js";
 
 const program = new Command();
 
-program.name("skillbox").description("Local-first, agent-agnostic skills manager").version("0.3.0");
+program.name("skillbox").description("Local-first, agent-agnostic skills manager").version("0.3.1");
 
 registerAdd(program);
 registerAgent(program);


### PR DESCRIPTION
## Summary

Bumps version to 0.3.1 for new release.

## Changes since 0.3.0

- Improved symlink warning messages - cleaner format and skips warnings when symlinks already point to correct location