### PR TITLE
fix: prevent recursive symlinks during skill update

### DIFF
--- a/src/lib/sync.ts
+++ b/src/lib/sync.ts
@@ -78,9 +78,8 @@ export async function installSkillToTargets(
   const sourceDir = skillDir(skillName);
   const results: InstallResult[] = [];
 
-  for (const targetRoot of targets) {
-    const targetDir = path.join(targetRoot, skillName);
-    await ensureDir(targetRoot);
+  for (const targetDir of targets) {
+    await ensureDir(path.dirname(targetDir));
 
     if (config.installMode === "symlink") {
       try {


### PR DESCRIPTION
## Summary

- Fixes a bug where `skillbox update` created recursive symlinks inside skill directories
- `installSkillToTargets` was appending `skillName` to paths that already included it
- This caused infinite nesting when agent install paths were symlinks to the canonical store

## Root Cause

`getInstallPaths()` returns full paths like `~/.claude/skills/my-skill`, but `installSkillToTargets` was doing:

```js
const targetDir = path.join(targetRoot, skillName);
// Result: ~/.claude/skills/my-skill/my-skill
```

Since `~/.claude/skills/my-skill` is a symlink to `~/.config/skillbox/skills/my-skill`, the nested symlink ended up in the canonical store, creating infinite recursion.

## Fix

Remove the redundant `path.join()` and use the target path directly:

```js
for (const targetDir of targets) {
  await ensureDir(path.dirname(targetDir));
```

## Test Plan

- [x] `skillbox update <skill>` no longer creates nested symlinks
- [x] `skillbox add` works correctly  
- [x] `skillbox status` shows all skills as up-to-date
- [x] Symlinked skills (pointing to external git repos) update correctly