### PR TITLE
chore: bump version to 0.3.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "skillbox",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "skillbox",
-      "version": "0.3.1",
+      "version": "0.3.2",
       "license": "MIT",
       "dependencies": {
         "chalk": "^5.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "skillbox",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "Local-first, agent-agnostic skills manager",
   "license": "MIT",
   "author": "Christian Anagnostou",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -14,7 +14,7 @@ import { registerUpdate } from "./commands/update.js";
 
 const program = new Command();
 
-program.name("skillbox").description("Local-first, agent-agnostic skills manager").version("0.3.1");
+program.name("skillbox").description("Local-first, agent-agnostic skills manager").version("0.3.2");
 
 registerAdd(program);
 registerAgent(program);


### PR DESCRIPTION
## Summary

Bump version to 0.3.2 for release.

## Changes since 0.3.1

- fix: prevent recursive symlinks during skill update (#27)