### PR TITLE
feat: add GitHub authentication for private repos

### DIFF
--- a/src/lib/fetcher.ts
+++ b/src/lib/fetcher.ts
@@ -13,7 +13,9 @@ function getGitHubToken(): string | null {
     cachedToken = envToken;
   } else {
     try {
-      cachedToken = execSync("gh auth token", { encoding: "utf8", stdio: ["pipe", "pipe", "pipe"] }).trim() || null;
+      cachedToken =
+        execSync("gh auth token", { encoding: "utf8", stdio: ["pipe", "pipe", "pipe"] }).trim() ||
+        null;
     } catch {
       cachedToken = null;
     }


### PR DESCRIPTION
## Summary

- Adds automatic GitHub authentication when fetching from private repos
- Checks `GITHUB_TOKEN` or `GH_TOKEN` environment variables first
- Falls back to `gh auth token` CLI command if no env var is set
- Caches token for the process lifetime to avoid repeated lookups

## Changes

```mermaid
flowchart TD
    A[fetchText called] --> B{Is GitHub URL?}
    B -->|No| C[Fetch without auth]
    B -->|Yes| D{Token cached?}
    D -->|Yes| E[Use cached token]
    D -->|No| F{GITHUB_TOKEN or GH_TOKEN set?}
    F -->|Yes| G[Use env token]
    F -->|No| H[Try gh auth token]
    H --> I{Success?}
    I -->|Yes| J[Use CLI token]
    I -->|No| K[Fetch without auth]
    E --> L[Add Authorization header]
    G --> L
    J --> L
    L --> M[Fetch with auth]
```

## Test plan

- [x] Verified `skillbox add https://github.com/vuori-clothing/skills --list` works with private repo
- [x] Verified `skillbox add https://github.com/vuori-clothing/skills` installs skills from private repo
- [x] Public repos continue to work (no auth required, but auth doesn't break them)