### PR TITLE
feat: add real-time progress indicator to update command

### DIFF
--- a/src/lib/output.ts
+++ b/src/lib/output.ts
@@ -14,6 +14,44 @@ export function isJsonEnabled(options: { json?: boolean }): boolean {
   return Boolean(options.json);
 }
 
+// Progress indicator support
+const isTTY = process.stdout.isTTY ?? false;
+
+// Braille spinner frames (single character, smooth animation)
+const SPINNER_FRAMES = ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"];
+
+let spinnerInterval: ReturnType<typeof setInterval> | null = null;
+let spinnerFrame = 0;
+
+export function startSpinner(message: string): void {
+  if (!isTTY) return;
+
+  spinnerFrame = 0;
+  const render = () => {
+    const frame = SPINNER_FRAMES[spinnerFrame % SPINNER_FRAMES.length];
+    process.stdout.write(`\r\x1b[K  ${frame} ${message}`);
+    spinnerFrame++;
+  };
+
+  render();
+  spinnerInterval = setInterval(render, 80);
+}
+
+export function stopSpinner(): void {
+  if (spinnerInterval) {
+    clearInterval(spinnerInterval);
+    spinnerInterval = null;
+  }
+  if (isTTY) {
+    process.stdout.write(`\r\x1b[K`);
+  }
+}
+
+export function printProgressResult(message: string): void {
+  stopSpinner();
+  process.stdout.write(`${message}\n`);
+}
+
 export function printJson(result: JsonResult): void {
   process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
 }

--- a/tests/helpers/environment.ts
+++ b/tests/helpers/environment.ts
@@ -292,4 +292,22 @@ export class TestEnvironment {
     await fs.writeFile(path.join(skillDir, "SKILL.md"), content);
     return skillDir;
   }
+
+  async addSkillToIndex(skill: {
+    name: string;
+    source: { type: string; url?: string; repo?: string; path?: string; ref?: string };
+    checksum?: string;
+    updatedAt?: string;
+  }): Promise<void> {
+    const indexPath = path.join(this.configDir, "index.json");
+    const index = await this.readJson<{ version: number; skills: unknown[] }>(indexPath);
+    index.skills.push({
+      name: skill.name,
+      source: skill.source,
+      checksum: skill.checksum ?? `test-checksum-${skill.name}`,
+      updatedAt: skill.updatedAt ?? new Date().toISOString(),
+      installs: [],
+    });
+    await fs.writeFile(indexPath, JSON.stringify(index, null, 2));
+  }
 }


### PR DESCRIPTION
## Summary

- Add animated braille spinner while each skill is being updated
- Show progress counter `(1/8)` on the spinner line only  
- Display immediate success/failure feedback for each skill
- Remove redundant grouped output since progress is now shown in real-time

## Example Output

```
Updating 8 skills...

  ⠋ agent-browser (1/8)    <- animated spinner while updating
  ✓ agent-browser          <- result shown immediately
  ⠙ clean-code (2/8)
  ✓ clean-code
  ...

Updated 8 of 8 trackable skills.
```

## Test plan

- [x] `npm run build` passes
- [x] `npm run lint` passes  
- [x] `npm test` passes (64 tests)
- [x] Manual testing of `skillbox update` command
- [x] JSON output mode (`--json`) remains unchanged