### PR TITLE
feat: add skillbox show command

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -11,6 +11,7 @@ import { registerList } from "./commands/list.js";
 import { registerMeta } from "./commands/meta.js";
 import { registerProject } from "./commands/project.js";
 import { registerRemove } from "./commands/remove.js";
+import { registerShow } from "./commands/show.js";
 import { registerStatus } from "./commands/status.js";
 import { registerUpdate } from "./commands/update.js";
 
@@ -29,6 +30,7 @@ registerList(program);
 registerMeta(program);
 registerProject(program);
 registerRemove(program);
+registerShow(program);
 registerStatus(program);
 registerUpdate(program);
 

--- a/src/commands/list.ts
+++ b/src/commands/list.ts
@@ -1,6 +1,5 @@
 import chalk from "chalk";
 import type { Command } from "commander";
-import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import terminalLink from "terminal-link";
@@ -10,6 +9,7 @@ import { loadIndex } from "../lib/index.js";
 import { isProjectInstall, isUserInstall } from "../lib/installs.js";
 import { isJsonEnabled, printInfo, printJson } from "../lib/output.js";
 import { resolveRuntime } from "../lib/runtime.js";
+import { readSkillDirEntries } from "../lib/skill-store.js";
 import { groupAndSort, sortByName } from "../lib/source-grouping.js";
 import type { SkillInstall } from "../lib/types.js";
 
@@ -51,25 +51,6 @@ type SkillWithSubcommands = SkillEntry & {
   subcommands: string[];
 };
 
-async function detectSubcommands(skillPath: string): Promise<string[]> {
-  try {
-    const entries = await fs.readdir(skillPath);
-    const subcommands: string[] = [];
-
-    for (const entry of entries) {
-      if (entry === "SKILL.md") continue;
-      if (!entry.endsWith(".md")) continue;
-
-      const name = entry.replace(/\.md$/, "");
-      subcommands.push(name);
-    }
-
-    return subcommands.sort();
-  } catch {
-    return [];
-  }
-}
-
 function getSkillPath(skill: SkillEntry): string | null {
   if (!skill.installs || skill.installs.length === 0) return null;
   return skill.installs[0].path;
@@ -80,7 +61,9 @@ async function enrichWithSubcommands(skills: SkillEntry[]): Promise<SkillWithSub
 
   for (const skill of skills) {
     const skillPath = getSkillPath(skill);
-    const subcommands = skillPath ? await detectSubcommands(skillPath) : [];
+    const { subcommands } = skillPath
+      ? await readSkillDirEntries(skillPath)
+      : { subcommands: [] };
     results.push({ ...skill, subcommands });
   }
 

--- a/src/commands/list.ts
+++ b/src/commands/list.ts
@@ -61,9 +61,7 @@ async function enrichWithSubcommands(skills: SkillEntry[]): Promise<SkillWithSub
 
   for (const skill of skills) {
     const skillPath = getSkillPath(skill);
-    const { subcommands } = skillPath
-      ? await readSkillDirEntries(skillPath)
-      : { subcommands: [] };
+    const { subcommands } = skillPath ? await readSkillDirEntries(skillPath) : { subcommands: [] };
     results.push({ ...skill, subcommands });
   }
 

--- a/src/commands/show.ts
+++ b/src/commands/show.ts
@@ -1,0 +1,130 @@
+import chalk from "chalk";
+import type { Command } from "commander";
+import fs from "node:fs/promises";
+import path from "node:path";
+import { handleCommandError } from "../lib/command.js";
+import { loadIndex } from "../lib/index.js";
+import { isJsonEnabled, printInfo, printJson } from "../lib/output.js";
+import { readSkillMetadata, skillDir } from "../lib/skill-store.js";
+
+async function detectSubcommands(dir: string): Promise<string[]> {
+  try {
+    const entries = await fs.readdir(dir);
+    return entries
+      .filter((e) => e.endsWith(".md") && e !== "SKILL.md")
+      .map((e) => e.replace(/\.md$/, ""))
+      .sort();
+  } catch {
+    return [];
+  }
+}
+
+async function listExtraFiles(dir: string): Promise<string[]> {
+  try {
+    const entries = await fs.readdir(dir);
+    return entries.filter((e) => e !== "SKILL.md" && e !== "skill.json").sort();
+  } catch {
+    return [];
+  }
+}
+
+export function registerShow(program: Command): void {
+  program
+    .command("show")
+    .argument("<name>", "Skill name")
+    .option("--json", "JSON output")
+    .action(async (name, options) => {
+      try {
+        const index = await loadIndex();
+        const indexed = index.skills.find((s) => s.name === name);
+
+        if (!indexed) {
+          throw new Error(`Skill not found: ${name}`);
+        }
+
+        const dir = skillDir(name);
+        const skillMdPath = path.join(dir, "SKILL.md");
+
+        let content: string;
+        try {
+          content = await fs.readFile(skillMdPath, "utf8");
+        } catch {
+          throw new Error(`Skill files missing for: ${name}`);
+        }
+
+        const metadata = await readSkillMetadata(name);
+        const subcommands = await detectSubcommands(dir);
+        const extraFiles = await listExtraFiles(dir);
+
+        if (isJsonEnabled(options)) {
+          printJson({
+            ok: true,
+            command: "show",
+            data: {
+              name,
+              description: metadata.description,
+              source: indexed.source,
+              checksum: indexed.checksum,
+              updatedAt: indexed.updatedAt,
+              installs: indexed.installs ?? [],
+              subcommands,
+              extraFiles,
+              content,
+            },
+          });
+          return;
+        }
+
+        // Header
+        printInfo(chalk.bold(name));
+        if (metadata.description) {
+          printInfo(chalk.dim(metadata.description));
+        }
+        printInfo("");
+
+        // Metadata
+        printInfo(`Source: ${formatSource(indexed.source)}`);
+        printInfo(`Updated: ${indexed.updatedAt}`);
+
+        // Installs
+        const installs = indexed.installs ?? [];
+        if (installs.length > 0) {
+          printInfo("");
+          printInfo(`Installs (${installs.length})`);
+          for (const install of installs) {
+            const scope = install.scope === "project" ? `project: ${install.projectRoot}` : "user";
+            printInfo(`  ${scope}/${install.agent}`);
+          }
+        }
+
+        // Subcommands
+        if (subcommands.length > 0) {
+          printInfo("");
+          printInfo(`Subcommands (${subcommands.length})`);
+          for (const sub of subcommands) {
+            printInfo(`  ${sub}`);
+          }
+        }
+
+        // Content
+        printInfo("");
+        printInfo(chalk.dim("─".repeat(40)));
+        printInfo(content.trim());
+      } catch (error) {
+        handleCommandError(options, "show", error);
+      }
+    });
+}
+
+function formatSource(source: {
+  type: string;
+  url?: string;
+  repo?: string;
+  path?: string;
+}): string {
+  if (source.type === "url" && source.url) return source.url;
+  if (source.type === "git" && source.repo) {
+    return source.path ? `${source.repo} (${source.path})` : source.repo;
+  }
+  return source.type;
+}

--- a/src/commands/show.ts
+++ b/src/commands/show.ts
@@ -5,28 +5,7 @@ import path from "node:path";
 import { handleCommandError } from "../lib/command.js";
 import { loadIndex } from "../lib/index.js";
 import { isJsonEnabled, printInfo, printJson } from "../lib/output.js";
-import { readSkillMetadata, skillDir } from "../lib/skill-store.js";
-
-async function detectSubcommands(dir: string): Promise<string[]> {
-  try {
-    const entries = await fs.readdir(dir);
-    return entries
-      .filter((e) => e.endsWith(".md") && e !== "SKILL.md")
-      .map((e) => e.replace(/\.md$/, ""))
-      .sort();
-  } catch {
-    return [];
-  }
-}
-
-async function listExtraFiles(dir: string): Promise<string[]> {
-  try {
-    const entries = await fs.readdir(dir);
-    return entries.filter((e) => e !== "SKILL.md" && e !== "skill.json").sort();
-  } catch {
-    return [];
-  }
-}
+import { readSkillDirEntries, readSkillMetadata, skillDir } from "../lib/skill-store.js";
 
 export function registerShow(program: Command): void {
   program
@@ -53,8 +32,7 @@ export function registerShow(program: Command): void {
         }
 
         const metadata = await readSkillMetadata(name);
-        const subcommands = await detectSubcommands(dir);
-        const extraFiles = await listExtraFiles(dir);
+        const { subcommands, extraFiles } = await readSkillDirEntries(dir);
 
         if (isJsonEnabled(options)) {
           printJson({

--- a/src/lib/skill-store.ts
+++ b/src/lib/skill-store.ts
@@ -58,6 +58,24 @@ export function hashContent(content: string): string {
  * and writes to the skill store. Returns the data needed for index updates,
  * or null if the skill is invalid (missing description).
  */
+export async function readSkillDirEntries(
+  dir: string
+): Promise<{ subcommands: string[]; extraFiles: string[] }> {
+  try {
+    const entries = await fs.readdir(dir);
+    const subcommands: string[] = [];
+    const extraFiles: string[] = [];
+    for (const e of entries) {
+      if (e === "SKILL.md" || e === "skill.json") continue;
+      if (e.endsWith(".md")) subcommands.push(e.replace(/\.md$/, ""));
+      else extraFiles.push(e);
+    }
+    return { subcommands: subcommands.sort(), extraFiles: extraFiles.sort() };
+  } catch {
+    return { subcommands: [], extraFiles: [] };
+  }
+}
+
 export async function importSkillFromDir(skillFile: string): Promise<ImportedSkillData | null> {
   const markdown = await fs.readFile(skillFile, "utf8");
   const parsed = parseSkillMarkdown(markdown);

--- a/tests/integration/show.test.ts
+++ b/tests/integration/show.test.ts
@@ -1,0 +1,121 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { runCli, runCliJson, assertJsonResponse } from "../helpers/cli.js";
+import { VALID_SKILL_MARKDOWN, VALID_SKILL_WITH_SUBCOMMANDS } from "../helpers/fixtures.js";
+import { testEnv } from "../setup.js";
+
+describe("show command", () => {
+  beforeEach(async () => {
+    await testEnv.installLocalSkill("show-skill", VALID_SKILL_MARKDOWN, {
+      description: "A skill to show",
+    });
+  });
+
+  it("shows skill details in JSON mode", async () => {
+    const { result, data } = await runCliJson<{
+      ok: boolean;
+      command: string;
+      data: {
+        name: string;
+        description: string;
+        source: { type: string };
+        content: string;
+        subcommands: string[];
+        extraFiles: string[];
+        installs: Array<{ scope: string; agent: string }>;
+      };
+    }>(["show", "show-skill"]);
+
+    expect(result.exitCode).toBe(0);
+    assertJsonResponse(result, { ok: true, command: "show" });
+    expect(data?.data.name).toBe("show-skill");
+    expect(data?.data.description).toBe("A skill to show");
+    expect(data?.data.source.type).toBe("local");
+    expect(data?.data.content).toContain("test skill");
+    expect(data?.data.subcommands).toEqual([]);
+    expect(data?.data.installs.length).toBeGreaterThan(0);
+  });
+
+  it("shows skill details in human-readable mode", async () => {
+    const result = await runCli(["show", "show-skill"]);
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toContain("show-skill");
+    expect(result.stdout).toContain("Source: local");
+    expect(result.stdout).toContain("Updated:");
+  });
+
+  it("shows error for non-existent skill", async () => {
+    const result = await runCli(["show", "nonexistent-skill"]);
+
+    expect(result.stdout + result.stderr).toMatch(/not found|error/i);
+  });
+
+  it("shows error for non-existent skill in JSON mode", async () => {
+    const { result, data } = await runCliJson<{
+      ok: boolean;
+      command: string;
+      error: { message: string };
+    }>(["show", "nonexistent-skill"]);
+
+    assertJsonResponse(result, { ok: false, command: "show" });
+    expect((data as Record<string, unknown>)?.error).toBeDefined();
+  });
+
+  it("shows subcommands when present", async () => {
+    await testEnv.installLocalSkill("multi-skill", VALID_SKILL_WITH_SUBCOMMANDS, {
+      description: "A skill with subcommands",
+      subcommands: {
+        one: "# Subcommand One\nFirst subcommand.",
+        two: "# Subcommand Two\nSecond subcommand.",
+      },
+    });
+
+    const { data } = await runCliJson<{
+      data: {
+        subcommands: string[];
+        extraFiles: string[];
+      };
+    }>(["show", "multi-skill"]);
+
+    expect(data?.data.subcommands).toContain("one");
+    expect(data?.data.subcommands).toContain("two");
+  });
+
+  it("shows subcommands in human-readable mode", async () => {
+    await testEnv.installLocalSkill("multi-skill-hr", VALID_SKILL_WITH_SUBCOMMANDS, {
+      description: "A skill with subcommands",
+      subcommands: {
+        alpha: "# Alpha\nAlpha subcommand.",
+        beta: "# Beta\nBeta subcommand.",
+      },
+    });
+
+    const result = await runCli(["show", "multi-skill-hr"]);
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toContain("Subcommands (2)");
+    expect(result.stdout).toContain("alpha");
+    expect(result.stdout).toContain("beta");
+  });
+
+  it("shows install information", async () => {
+    const { data } = await runCliJson<{
+      data: {
+        installs: Array<{ scope: string; agent: string; path: string }>;
+      };
+    }>(["show", "show-skill"]);
+
+    const installs = data?.data.installs ?? [];
+    expect(installs.length).toBeGreaterThan(0);
+    expect(installs[0].scope).toBe("user");
+    expect(installs[0].agent).toBe("claude");
+  });
+
+  it("renders content in human-readable mode", async () => {
+    const result = await runCli(["show", "show-skill"]);
+
+    expect(result.exitCode).toBe(0);
+    // Content section should include the SKILL.md body
+    expect(result.stdout).toContain("Test Skill");
+  });
+});


### PR DESCRIPTION
## Summary
- Adds `skillbox show <name>` command that renders a skill's SKILL.md content and metadata in a human-readable format
- Supports `--json` output for agent/automation consumption
- Shows source info, install locations, subcommands, and full skill content
- Includes integration tests covering JSON/human output, subcommands, error cases

Closes #35

## Test plan
- [x] `skillbox show <name>` displays skill content and metadata
- [x] `skillbox show <name> --json` outputs structured JSON with all fields
- [x] Shows subcommands when present
- [x] Shows install information (scope/agent)
- [x] Error handling for non-existent skills
- [x] All 8 integration tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)