### PR TITLE
feat: show installed agents in list output

### DIFF
--- a/src/commands/list.ts
+++ b/src/commands/list.ts
@@ -7,16 +7,11 @@ import terminalLink from "terminal-link";
 import { allAgents, type AgentId } from "../lib/agents.js";
 import { discoverGlobalSkills } from "../lib/global-skills.js";
 import { loadIndex } from "../lib/index.js";
+import { isProjectInstall, isUserInstall } from "../lib/installs.js";
 import { isJsonEnabled, printInfo, printJson } from "../lib/output.js";
 import { resolveRuntime } from "../lib/runtime.js";
 import { groupAndSort, sortByName } from "../lib/source-grouping.js";
-
-type SkillInstall = {
-  scope: "user" | "project";
-  agent?: string;
-  path: string;
-  projectRoot?: string;
-};
+import type { SkillInstall } from "../lib/types.js";
 
 type SkillEntry = {
   name: string;
@@ -112,8 +107,8 @@ function groupByScope(skills: SkillWithSubcommands[]): ScopeGroup[] {
   const projectSkills: SkillWithSubcommands[] = [];
 
   for (const skill of skills) {
-    const hasProjectInstall = skill.installs?.some((i) => i.scope === "project");
-    const hasUserInstall = skill.installs?.some((i) => i.scope === "user");
+    const hasProjectInstall = skill.installs?.some(isProjectInstall);
+    const hasUserInstall = skill.installs?.some(isUserInstall);
 
     // A skill can be in both - for now, categorize by where it's installed
     if (hasProjectInstall) {
@@ -178,9 +173,8 @@ function groupBySourceType(
 
 function getProjectRoots(skill: SkillWithSubcommands): string[] {
   const roots = (skill.installs ?? [])
-    .filter((install) => install.scope === "project")
-    .map((install) => install.projectRoot)
-    .filter((root): root is string => Boolean(root));
+    .filter(isProjectInstall)
+    .map((install) => install.projectRoot);
   return Array.from(new Set(roots));
 }
 
@@ -257,12 +251,11 @@ function getAgentInstallRoots(
   projectRoot?: string
 ): Array<{ agent: string; root: string }> {
   const rootsByAgent = new Map<string, string>();
-  const targetScope = projectRoot ? "project" : "user";
+  const matchesScope = projectRoot ? isProjectInstall : isUserInstall;
   for (const skill of skills) {
     if (!skill.installs) continue;
     for (const install of skill.installs) {
-      if (!install.agent) continue;
-      if (install.scope !== targetScope) continue;
+      if (!matchesScope(install)) continue;
       if (rootsByAgent.has(install.agent)) continue;
       const dirPath = path.dirname(install.path);
       const displayPath = projectRoot
@@ -380,13 +373,10 @@ function filterByAgents(skills: SkillEntry[], agents: string[]): SkillEntry[] {
 
 function filterUserScope(skills: SkillEntry[]): SkillEntry[] {
   return skills
-    .filter(
-      (skill) =>
-        skill.installs?.some((install) => install.scope === "user") ?? !skill.installs?.length
-    )
+    .filter((skill) => skill.installs?.some(isUserInstall) ?? !skill.installs?.length)
     .map((skill) => ({
       ...skill,
-      installs: skill.installs?.filter((install) => install.scope === "user"),
+      installs: skill.installs?.filter(isUserInstall),
     }));
 }
 

--- a/src/commands/list.ts
+++ b/src/commands/list.ts
@@ -1,6 +1,8 @@
 import chalk from "chalk";
 import type { Command } from "commander";
 import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
 import terminalLink from "terminal-link";
 import type { AgentId } from "../lib/agents.js";
 import { discoverGlobalSkills } from "../lib/global-skills.js";
@@ -241,6 +243,50 @@ function renderSkillLine(
   return `${base} ${chalk.dim(`[${divergence}]`)}`;
 }
 
+function tildify(absolutePath: string): string {
+  const home = os.homedir();
+  if (absolutePath === home) return "~";
+  if (absolutePath.startsWith(`${home}/`)) {
+    return `~${absolutePath.slice(home.length)}`;
+  }
+  return absolutePath;
+}
+
+function getAgentInstallRoots(
+  skills: SkillEntry[],
+  projectRoot?: string
+): Array<{ agent: string; root: string }> {
+  const rootsByAgent = new Map<string, string>();
+  const targetScope = projectRoot ? "project" : "user";
+  for (const skill of skills) {
+    if (!skill.installs) continue;
+    for (const install of skill.installs) {
+      if (!install.agent) continue;
+      if (install.scope !== targetScope) continue;
+      if (rootsByAgent.has(install.agent)) continue;
+      const dirPath = path.dirname(install.path);
+      const displayPath = projectRoot
+        ? path.relative(projectRoot, dirPath) || "."
+        : tildify(dirPath);
+      rootsByAgent.set(install.agent, displayPath);
+    }
+  }
+  return Array.from(rootsByAgent.entries())
+    .sort(([a], [b]) => a.localeCompare(b))
+    .map(([agent, root]) => ({ agent, root }));
+}
+
+function printAgentInstallTable(
+  agentRoots: Array<{ agent: string; root: string }>,
+  indent: string
+): void {
+  if (agentRoots.length === 0) return;
+  const maxAgentLen = Math.max(...agentRoots.map((entry) => entry.agent.length));
+  for (const { agent, root } of agentRoots) {
+    printInfo(`${indent}${chalk.dim(`${agent.padEnd(maxAgentLen)} → ${root}`)}`);
+  }
+}
+
 function printScopeGroup(group: ScopeGroup, showAgents: boolean): void {
   const label = group.scope === "global" ? "Global Skills" : "Project Skills";
   const totalCount = group.sourceGroups.reduce((sum, g) => sum + g.skills.length, 0);
@@ -257,17 +303,21 @@ function printScopeGroup(group: ScopeGroup, showAgents: boolean): void {
     if (!modalAgents) return null;
     return formatAgentDivergence(agentsBySkill.get(skill) ?? [], modalAgents);
   };
-  const headerSuffix =
-    modalAgents && modalAgents.length > 0 ? chalk.dim(`  — agents: ${modalAgents.join(", ")}`) : "";
 
-  printInfo(`${label} (${totalCount})${headerSuffix}`);
+  printInfo(`${label} (${totalCount})`);
 
   if (group.scope === "project" && group.projectGroups) {
     for (const projectGroup of group.projectGroups) {
       printInfo("");
       printInfo(projectGroup.projectRoot);
 
+      if (showAgents) {
+        const projectSkills = projectGroup.sourceGroups.flatMap((g) => g.skills);
+        printAgentInstallTable(getAgentInstallRoots(projectSkills, projectGroup.projectRoot), "  ");
+      }
+
       for (const sourceGroup of projectGroup.sourceGroups) {
+        printInfo("");
         printInfo(`  ${sourceGroup.source}`);
 
         for (const skill of sourceGroup.skills) {
@@ -280,6 +330,10 @@ function printScopeGroup(group: ScopeGroup, showAgents: boolean): void {
       }
     }
     return;
+  }
+
+  if (showAgents) {
+    printAgentInstallTable(getAgentInstallRoots(allSkills), "  ");
   }
 
   for (const sourceGroup of group.sourceGroups) {

--- a/src/commands/list.ts
+++ b/src/commands/list.ts
@@ -182,11 +182,80 @@ function getProjectRoots(skill: SkillWithSubcommands): string[] {
   return Array.from(new Set(roots));
 }
 
-function printScopeGroup(group: ScopeGroup): void {
+function getSkillAgents(skill: SkillEntry): string[] {
+  if (!skill.installs) return [];
+  const agents = new Set<string>();
+  for (const install of skill.installs) {
+    if (install.agent) agents.add(install.agent);
+  }
+  return Array.from(agents).sort();
+}
+
+function getModalAgentSet(skills: SkillEntry[]): string[] | null {
+  const counts = new Map<string, { agents: string[]; count: number }>();
+  for (const skill of skills) {
+    const agents = getSkillAgents(skill);
+    if (agents.length === 0) continue;
+    const key = agents.join(",");
+    const existing = counts.get(key);
+    if (existing) {
+      existing.count++;
+    } else {
+      counts.set(key, { agents, count: 1 });
+    }
+  }
+  if (counts.size === 0) return null;
+  let best: { agents: string[]; count: number } | null = null;
+  for (const entry of counts.values()) {
+    if (
+      !best ||
+      entry.count > best.count ||
+      (entry.count === best.count && entry.agents.length > best.agents.length)
+    ) {
+      best = entry;
+    }
+  }
+  return best?.agents ?? null;
+}
+
+function arraysEqual(a: string[], b: string[]): boolean {
+  if (a.length !== b.length) return false;
+  return a.every((value, index) => value === b[index]);
+}
+
+function formatAgentDivergence(skillAgents: string[], modalAgents: string[]): string | null {
+  if (arraysEqual(skillAgents, modalAgents)) return null;
+  if (skillAgents.length === 0) return "no agents";
+  const isStrictSubset =
+    skillAgents.length < modalAgents.length &&
+    skillAgents.every((agent) => modalAgents.includes(agent));
+  if (isStrictSubset) {
+    return `${skillAgents.join(", ")} only`;
+  }
+  return skillAgents.join(", ");
+}
+
+function renderSkillLine(
+  indent: string,
+  skill: SkillWithSubcommands,
+  modalAgents: string[] | null
+): string {
+  const base = `${indent}${linkSkillName(skill)}`;
+  if (!modalAgents) return base;
+  const divergence = formatAgentDivergence(getSkillAgents(skill), modalAgents);
+  if (!divergence) return base;
+  return `${base} ${chalk.dim(`[${divergence}]`)}`;
+}
+
+function printScopeGroup(group: ScopeGroup, showAgents: boolean): void {
   const label = group.scope === "global" ? "Global Skills" : "Project Skills";
   const totalCount = group.sourceGroups.reduce((sum, g) => sum + g.skills.length, 0);
+  const allSkills = group.sourceGroups.flatMap((g) => g.skills);
+  const modalAgents = showAgents ? getModalAgentSet(allSkills) : null;
+  const headerSuffix =
+    modalAgents && modalAgents.length > 0 ? chalk.dim(`  — agents: ${modalAgents.join(", ")}`) : "";
 
-  printInfo(`${label} (${totalCount})`);
+  printInfo(`${label} (${totalCount})${headerSuffix}`);
 
   if (group.scope === "project" && group.projectGroups) {
     for (const projectGroup of group.projectGroups) {
@@ -197,7 +266,7 @@ function printScopeGroup(group: ScopeGroup): void {
         printInfo(`  ${sourceGroup.source}`);
 
         for (const skill of sourceGroup.skills) {
-          printInfo(`    ${linkSkillName(skill)}`);
+          printInfo(renderSkillLine("    ", skill, modalAgents));
 
           if (skill.subcommands.length > 0) {
             printInfo(`      → ${skill.subcommands.join(", ")}`);
@@ -213,7 +282,7 @@ function printScopeGroup(group: ScopeGroup): void {
     printInfo(`${sourceGroup.source}`);
 
     for (const skill of sourceGroup.skills) {
-      printInfo(`  ${linkSkillName(skill)}`);
+      printInfo(renderSkillLine("  ", skill, modalAgents));
 
       if (skill.subcommands.length > 0) {
         printInfo(`    → ${skill.subcommands.join(", ")}`);
@@ -303,9 +372,10 @@ export function registerList(program: Command): void {
         return;
       }
 
+      const showAgents = !options.agents;
       for (let i = 0; i < scopeGroups.length; i++) {
         if (i > 0) printInfo("");
-        printScopeGroup(scopeGroups[i]);
+        printScopeGroup(scopeGroups[i], showAgents);
       }
     });
 }

--- a/src/commands/list.ts
+++ b/src/commands/list.ts
@@ -191,10 +191,9 @@ function getSkillAgents(skill: SkillEntry): string[] {
   return Array.from(agents).sort();
 }
 
-function getModalAgentSet(skills: SkillEntry[]): string[] | null {
+function getModalAgentSet(agentsBySkill: Map<SkillEntry, string[]>): string[] | null {
   const counts = new Map<string, { agents: string[]; count: number }>();
-  for (const skill of skills) {
-    const agents = getSkillAgents(skill);
+  for (const agents of agentsBySkill.values()) {
     if (agents.length === 0) continue;
     const key = agents.join(",");
     const existing = counts.get(key);
@@ -205,17 +204,14 @@ function getModalAgentSet(skills: SkillEntry[]): string[] | null {
     }
   }
   if (counts.size === 0) return null;
-  let best: { agents: string[]; count: number } | null = null;
-  for (const entry of counts.values()) {
-    if (
-      !best ||
-      entry.count > best.count ||
-      (entry.count === best.count && entry.agents.length > best.agents.length)
-    ) {
-      best = entry;
-    }
-  }
-  return best?.agents ?? null;
+  // Tie-break: prefer the smaller set so fewer skills get tagged as divergent.
+  // Final tie: alphabetical for determinism.
+  const sorted = Array.from(counts.values()).sort((a, b) => {
+    if (a.count !== b.count) return b.count - a.count;
+    if (a.agents.length !== b.agents.length) return a.agents.length - b.agents.length;
+    return a.agents.join(",").localeCompare(b.agents.join(","));
+  });
+  return sorted[0].agents;
 }
 
 function arraysEqual(a: string[], b: string[]): boolean {
@@ -238,11 +234,9 @@ function formatAgentDivergence(skillAgents: string[], modalAgents: string[]): st
 function renderSkillLine(
   indent: string,
   skill: SkillWithSubcommands,
-  modalAgents: string[] | null
+  divergence: string | null
 ): string {
   const base = `${indent}${linkSkillName(skill)}`;
-  if (!modalAgents) return base;
-  const divergence = formatAgentDivergence(getSkillAgents(skill), modalAgents);
   if (!divergence) return base;
   return `${base} ${chalk.dim(`[${divergence}]`)}`;
 }
@@ -251,7 +245,18 @@ function printScopeGroup(group: ScopeGroup, showAgents: boolean): void {
   const label = group.scope === "global" ? "Global Skills" : "Project Skills";
   const totalCount = group.sourceGroups.reduce((sum, g) => sum + g.skills.length, 0);
   const allSkills = group.sourceGroups.flatMap((g) => g.skills);
-  const modalAgents = showAgents ? getModalAgentSet(allSkills) : null;
+
+  const agentsBySkill = new Map<SkillEntry, string[]>();
+  if (showAgents) {
+    for (const skill of allSkills) {
+      agentsBySkill.set(skill, getSkillAgents(skill));
+    }
+  }
+  const modalAgents = showAgents ? getModalAgentSet(agentsBySkill) : null;
+  const divergenceFor = (skill: SkillEntry): string | null => {
+    if (!modalAgents) return null;
+    return formatAgentDivergence(agentsBySkill.get(skill) ?? [], modalAgents);
+  };
   const headerSuffix =
     modalAgents && modalAgents.length > 0 ? chalk.dim(`  — agents: ${modalAgents.join(", ")}`) : "";
 
@@ -266,7 +271,7 @@ function printScopeGroup(group: ScopeGroup, showAgents: boolean): void {
         printInfo(`  ${sourceGroup.source}`);
 
         for (const skill of sourceGroup.skills) {
-          printInfo(renderSkillLine("    ", skill, modalAgents));
+          printInfo(renderSkillLine("    ", skill, divergenceFor(skill)));
 
           if (skill.subcommands.length > 0) {
             printInfo(`      → ${skill.subcommands.join(", ")}`);
@@ -282,7 +287,7 @@ function printScopeGroup(group: ScopeGroup, showAgents: boolean): void {
     printInfo(`${sourceGroup.source}`);
 
     for (const skill of sourceGroup.skills) {
-      printInfo(renderSkillLine("  ", skill, modalAgents));
+      printInfo(renderSkillLine("  ", skill, divergenceFor(skill)));
 
       if (skill.subcommands.length > 0) {
         printInfo(`    → ${skill.subcommands.join(", ")}`);

--- a/src/commands/list.ts
+++ b/src/commands/list.ts
@@ -246,28 +246,44 @@ function tildify(absolutePath: string): string {
   return absolutePath;
 }
 
-function getAgentInstallRoots(
+function collectInstallDirsByAgent(
   skills: SkillEntry[],
-  projectRoot?: string
-): Array<{ agent: string; root: string }> {
-  const rootsByAgent = new Map<string, string>();
-  const matchesScope = projectRoot ? isProjectInstall : isUserInstall;
+  predicate: (install: SkillInstall) => boolean
+): Map<string, string> {
+  const dirsByAgent = new Map<string, string>();
   for (const skill of skills) {
     if (!skill.installs) continue;
     for (const install of skill.installs) {
-      if (!matchesScope(install)) continue;
-      if (rootsByAgent.has(install.agent)) continue;
-      const dirPath = path.dirname(install.path);
-      const displayPath = projectRoot
-        ? path.relative(projectRoot, dirPath) || "."
-        : tildify(dirPath);
-      rootsByAgent.set(install.agent, displayPath);
+      if (!predicate(install)) continue;
+      if (dirsByAgent.has(install.agent)) continue;
+      dirsByAgent.set(install.agent, path.dirname(install.path));
     }
   }
+  return dirsByAgent;
+}
+
+function toSortedAgentRoots(
+  dirsByAgent: Map<string, string>,
+  formatDir: (absoluteDir: string) => string
+): Array<{ agent: string; root: string }> {
   const orderIndex = new Map(allAgents.map((agent, i) => [agent as string, i]));
-  return Array.from(rootsByAgent.entries())
+  return Array.from(dirsByAgent.entries())
     .sort(([a], [b]) => (orderIndex.get(a) ?? Infinity) - (orderIndex.get(b) ?? Infinity))
-    .map(([agent, root]) => ({ agent, root }));
+    .map(([agent, dir]) => ({ agent, root: formatDir(dir) }));
+}
+
+function getUserAgentRoots(skills: SkillEntry[]): Array<{ agent: string; root: string }> {
+  return toSortedAgentRoots(collectInstallDirsByAgent(skills, isUserInstall), tildify);
+}
+
+function getProjectAgentRoots(
+  skills: SkillEntry[],
+  projectRoot: string
+): Array<{ agent: string; root: string }> {
+  return toSortedAgentRoots(
+    collectInstallDirsByAgent(skills, isProjectInstall),
+    (dir) => path.relative(projectRoot, dir) || "."
+  );
 }
 
 function printAgentInstallTable(
@@ -307,7 +323,7 @@ function printScopeGroup(group: ScopeGroup, showAgents: boolean): void {
 
       if (showAgents) {
         const projectSkills = projectGroup.sourceGroups.flatMap((g) => g.skills);
-        printAgentInstallTable(getAgentInstallRoots(projectSkills, projectGroup.projectRoot), "  ");
+        printAgentInstallTable(getProjectAgentRoots(projectSkills, projectGroup.projectRoot), "  ");
       }
 
       for (const sourceGroup of projectGroup.sourceGroups) {
@@ -327,7 +343,7 @@ function printScopeGroup(group: ScopeGroup, showAgents: boolean): void {
   }
 
   if (showAgents) {
-    printAgentInstallTable(getAgentInstallRoots(allSkills), "  ");
+    printAgentInstallTable(getUserAgentRoots(allSkills), "  ");
   }
 
   for (const sourceGroup of group.sourceGroups) {

--- a/src/commands/list.ts
+++ b/src/commands/list.ts
@@ -4,7 +4,7 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import terminalLink from "terminal-link";
-import type { AgentId } from "../lib/agents.js";
+import { allAgents, type AgentId } from "../lib/agents.js";
 import { discoverGlobalSkills } from "../lib/global-skills.js";
 import { loadIndex } from "../lib/index.js";
 import { isJsonEnabled, printInfo, printJson } from "../lib/output.js";
@@ -12,7 +12,7 @@ import { resolveRuntime } from "../lib/runtime.js";
 import { groupAndSort, sortByName } from "../lib/source-grouping.js";
 
 type SkillInstall = {
-  scope: string;
+  scope: "user" | "project";
   agent?: string;
   path: string;
   projectRoot?: string;
@@ -271,8 +271,9 @@ function getAgentInstallRoots(
       rootsByAgent.set(install.agent, displayPath);
     }
   }
+  const orderIndex = new Map(allAgents.map((agent, i) => [agent as string, i]));
   return Array.from(rootsByAgent.entries())
-    .sort(([a], [b]) => a.localeCompare(b))
+    .sort(([a], [b]) => (orderIndex.get(a) ?? Infinity) - (orderIndex.get(b) ?? Infinity))
     .map(([agent, root]) => ({ agent, root }));
 }
 

--- a/src/commands/remove.ts
+++ b/src/commands/remove.ts
@@ -3,15 +3,12 @@ import fs from "node:fs/promises";
 import path from "node:path";
 import { handleCommandError } from "../lib/command.js";
 import { loadIndex, saveIndex, sortIndex } from "../lib/index.js";
+import { isProjectInstall } from "../lib/installs.js";
 import { isJsonEnabled, printInfo, printJson } from "../lib/output.js";
 import { skillDir } from "../lib/skill-store.js";
+import type { SkillInstall } from "../lib/types.js";
 
-type InstallInfo = {
-  scope: string;
-  agent: string;
-  path: string;
-  projectRoot?: string;
-};
+type InstallInfo = SkillInstall;
 
 async function removePaths(paths: string[]): Promise<void> {
   for (const target of paths) {
@@ -23,7 +20,7 @@ function groupInstallsByScope(installs: InstallInfo[]): Map<string, InstallInfo[
   const groups = new Map<string, InstallInfo[]>();
 
   for (const install of installs) {
-    const key = install.scope === "project" ? `project:${install.projectRoot}` : "user";
+    const key = isProjectInstall(install) ? `project:${install.projectRoot}` : "user";
     const existing = groups.get(key) ?? [];
     existing.push(install);
     groups.set(key, existing);
@@ -70,12 +67,10 @@ export function registerRemove(program: Command): void {
         const projectRoot = options.project ? path.resolve(options.project) : null;
         const installs = skill.installs ?? [];
 
-        const isProjectInstall = (install: (typeof installs)[number]): boolean =>
-          install.scope === "project" &&
-          Boolean(install.projectRoot) &&
-          install.projectRoot === projectRoot;
+        const matchesProject = (install: (typeof installs)[number]): boolean =>
+          isProjectInstall(install) && install.projectRoot === projectRoot;
 
-        const toRemove = projectRoot ? installs.filter(isProjectInstall) : installs;
+        const toRemove = projectRoot ? installs.filter(matchesProject) : installs;
 
         if (projectRoot && toRemove.length === 0) {
           throw new Error(`No installs found for ${name} in ${projectRoot}.`);
@@ -86,7 +81,7 @@ export function registerRemove(program: Command): void {
 
         let removedCanonical = false;
         if (projectRoot) {
-          const remaining = installs.filter((install) => !isProjectInstall(install));
+          const remaining = installs.filter((install) => !matchesProject(install));
           index.skills = index.skills.map((entry) =>
             entry.name === name
               ? { ...entry, installs: remaining.length > 0 ? remaining : undefined }

--- a/src/commands/remove.ts
+++ b/src/commands/remove.ts
@@ -8,16 +8,14 @@ import { isJsonEnabled, printInfo, printJson } from "../lib/output.js";
 import { skillDir } from "../lib/skill-store.js";
 import type { SkillInstall } from "../lib/types.js";
 
-type InstallInfo = SkillInstall;
-
 async function removePaths(paths: string[]): Promise<void> {
   for (const target of paths) {
     await fs.rm(target, { recursive: true, force: true });
   }
 }
 
-function groupInstallsByScope(installs: InstallInfo[]): Map<string, InstallInfo[]> {
-  const groups = new Map<string, InstallInfo[]>();
+function groupInstallsByScope(installs: SkillInstall[]): Map<string, SkillInstall[]> {
+  const groups = new Map<string, SkillInstall[]>();
 
   for (const install of installs) {
     const key = isProjectInstall(install) ? `project:${install.projectRoot}` : "user";
@@ -29,7 +27,7 @@ function groupInstallsByScope(installs: InstallInfo[]): Map<string, InstallInfo[
   return groups;
 }
 
-function printRemovedInstalls(installs: InstallInfo[]): void {
+function printRemovedInstalls(installs: SkillInstall[]): void {
   const groups = groupInstallsByScope(installs);
 
   // Sort: user scope first, then projects
@@ -114,7 +112,7 @@ export function registerRemove(program: Command): void {
         if (toRemove.length > 0) {
           printInfo("");
           printInfo("Removed from:");
-          printRemovedInstalls(toRemove as InstallInfo[]);
+          printRemovedInstalls(toRemove);
         }
       } catch (error) {
         handleCommandError(options, "remove", error);

--- a/src/lib/installs.ts
+++ b/src/lib/installs.ts
@@ -1,9 +1,13 @@
 import type { IndexedSkill, SkillInstall } from "./types.js";
 
-function isProjectInstall(
+export function isProjectInstall(
   install: SkillInstall
 ): install is SkillInstall & { projectRoot: string } {
   return install.scope === "project" && Boolean(install.projectRoot);
+}
+
+export function isUserInstall(install: SkillInstall): install is SkillInstall & { scope: "user" } {
+  return install.scope === "user";
 }
 
 export function collectProjectSkills(skills: IndexedSkill[]): Map<string, string[]> {

--- a/tests/integration/list.test.ts
+++ b/tests/integration/list.test.ts
@@ -85,6 +85,36 @@ Main skill.`;
     });
   });
 
+  describe("agent annotation", () => {
+    beforeEach(async () => {
+      await testEnv.installLocalSkill("agent-tagged-skill", VALID_SKILL_MARKDOWN, {
+        description: "A skill for agent annotation",
+      });
+    });
+
+    it("shows the modal agent set in the scope header", async () => {
+      const result = await runCli(["list"]);
+
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).toMatch(/agents:\s+claude/);
+    });
+
+    it("does not tag skills that match the modal agent set", async () => {
+      const result = await runCli(["list"]);
+
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).toContain("agent-tagged-skill");
+      expect(result.stdout).not.toMatch(/agent-tagged-skill.*\[/);
+    });
+
+    it("suppresses the annotation when --agents filter is active", async () => {
+      const result = await runCli(["list", "--agents", "claude"]);
+
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).not.toMatch(/agents:\s+claude/);
+    });
+  });
+
   describe("filtering", () => {
     it("filters by --global flag", async () => {
       await testEnv.installLocalSkill("user-list-skill", VALID_SKILL_MARKDOWN, {

--- a/tests/integration/list.test.ts
+++ b/tests/integration/list.test.ts
@@ -92,11 +92,12 @@ Main skill.`;
       });
     });
 
-    it("shows the modal agent set in the scope header", async () => {
+    it("shows a per-agent install table under the scope header", async () => {
       const result = await runCli(["list"]);
 
       expect(result.exitCode).toBe(0);
-      expect(result.stdout).toMatch(/agents:\s+claude/);
+      expect(result.stdout).toMatch(/claude\s+→\s+/);
+      expect(result.stdout).toMatch(/[/~].*\/skills/);
     });
 
     it("does not tag skills that match the modal agent set", async () => {
@@ -107,11 +108,11 @@ Main skill.`;
       expect(result.stdout).not.toMatch(/agent-tagged-skill.*\[/);
     });
 
-    it("suppresses the annotation when --agents filter is active", async () => {
+    it("suppresses the install table when --agents filter is active", async () => {
       const result = await runCli(["list", "--agents", "claude"]);
 
       expect(result.exitCode).toBe(0);
-      expect(result.stdout).not.toMatch(/agents:\s+claude/);
+      expect(result.stdout).not.toMatch(/claude\s+→/);
     });
   });
 

--- a/tests/unit/installs.test.ts
+++ b/tests/unit/installs.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect } from "vitest";
+import { isProjectInstall, isUserInstall } from "../../src/lib/installs.js";
+import type { SkillInstall } from "../../src/lib/types.js";
+
+const userInstall: SkillInstall = {
+  scope: "user",
+  agent: "claude",
+  path: "/home/u/.claude/skills/foo",
+};
+
+const projectInstall: SkillInstall = {
+  scope: "project",
+  agent: "claude",
+  path: "/home/u/proj/.claude/skills/foo",
+  projectRoot: "/home/u/proj",
+};
+
+const projectInstallMissingRoot: SkillInstall = {
+  scope: "project",
+  agent: "claude",
+  path: "/home/u/proj/.claude/skills/foo",
+};
+
+describe("isProjectInstall", () => {
+  it("returns true for project installs with projectRoot", () => {
+    expect(isProjectInstall(projectInstall)).toBe(true);
+  });
+
+  it("returns false for project installs without projectRoot", () => {
+    expect(isProjectInstall(projectInstallMissingRoot)).toBe(false);
+  });
+
+  it("returns false for user installs", () => {
+    expect(isProjectInstall(userInstall)).toBe(false);
+  });
+});
+
+describe("isUserInstall", () => {
+  it("returns true for user installs", () => {
+    expect(isUserInstall(userInstall)).toBe(true);
+  });
+
+  it("returns false for project installs", () => {
+    expect(isUserInstall(projectInstall)).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

Surfaces per-skill agent install info — which already exists in `--json` output but was invisible in the formatted `skillbox list` view. Two additions, both opt-out via `--agents`:

1. **Per-agent install table** under each section header, mapping each agent to its install root. Tildified for user scope; relative to project root for project scope.
2. **Smart-omit divergence tag** per skill: a dim `[<agents> only]` (or `[<agents>]`) only on skills whose agent set differs from the modal pattern. Skills matching the modal show no extra annotation.

### Before

```
Global Skills (12)

local
  vuori-vault

git
  agent-browser
  clean-code
    → debug, duplicates, slop, unused
  create-pr
    → diagrams, template
```

### After

```
Global Skills (12)
  claude → ~/.claude/skills
  codex  → ~/.codex/skills

local
  vuori-vault [claude only]

git
  agent-browser
  clean-code
    → debug, duplicates, slop, unused
  create-pr
    → diagrams, template
```

`vuori-vault` is installed for claude only — a previously hidden divergence now surfaced. Install paths replace the need to run `--json` for a "where does this live?" check.

For project scope, the install table appears under each project root and uses relative paths (`.claude/skills/`, etc.).

## Test plan

- [x] `npm test` — 78 tests pass (75 existing + 3 new for agent annotation)
- [x] `npm run lint:ci` — clean
- [x] `npm run format:check` — clean
- [x] `npm run build` — clean
- [x] Manual: `skillbox list`, `skillbox list --agents claude`, `skillbox list --global`, `skillbox list --json`

## Notes

- **JSON output is unchanged.** All new info is presentation-layer only; the JSON `installs[]` already exposed `scope`, `agent`, and `path`.
- **`--agents <filter>` suppresses both** the install table and the per-skill divergence tag (would be redundant).
- **Modal tie-breaker** prefers the smaller agent set (so fewer skills get tagged as divergent on a tie) and falls back to alphabetical for deterministic output.
- **Dual-scope skills** (installed both user and project) appear under both headers as before — the duplication itself signals the dual-install case, so no extra tag is needed.