### PR TITLE
fix: read version from package.json, bump to 0.3.7

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "skillbox",
-  "version": "0.3.5",
+  "version": "0.3.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "skillbox",
-      "version": "0.3.5",
+      "version": "0.3.7",
       "license": "MIT",
       "dependencies": {
         "chalk": "^5.6.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "skillbox",
-  "version": "0.3.5",
+  "version": "0.3.6",
   "description": "Local-first, agent-agnostic skills manager",
   "homepage": "https://github.com/christiananagnostou/skillbox",
   "bugs": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "skillbox",
-  "version": "0.3.6",
+  "version": "0.3.7",
   "description": "Local-first, agent-agnostic skills manager",
   "homepage": "https://github.com/christiananagnostou/skillbox",
   "bugs": {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,5 +1,8 @@
 #!/usr/bin/env node
+import { createRequire } from "node:module";
 import { Command } from "commander";
+
+const { version } = createRequire(import.meta.url)("../package.json") as { version: string };
 import { registerAdd } from "./commands/add.js";
 import { registerAgent } from "./commands/agent.js";
 import { registerConfig } from "./commands/config.js";
@@ -17,7 +20,7 @@ import { registerUpdate } from "./commands/update.js";
 
 const program = new Command();
 
-program.name("skillbox").description("Local-first, agent-agnostic skills manager").version("0.3.4");
+program.name("skillbox").description("Local-first, agent-agnostic skills manager").version(version);
 
 registerAdd(program);
 registerAgent(program);


### PR DESCRIPTION
## Summary
- `--version` was reporting `0.3.4` even after the 0.3.5 release because the version string was hardcoded in `cli.ts` and the build artifact captured the old value
- Switch to `createRequire` to read `version` from `package.json` at runtime — stays in sync automatically on every future release
- Bumps to 0.37 to ship the corrected version string