### PR TITLE
fix: remote-check git skills in status

### DIFF
--- a/docs/masterplan.md
+++ b/docs/masterplan.md
@@ -1,0 +1,78 @@
+# Skillbox masterplan
+
+Living post-v1 backlog grounded in the 2026-08-06 implementation audit. Prefer this over ad-hoc next-step chat when prioritizing work.
+
+Related vault: `Brain/skillbox` → [[wiki/reference/known-gaps]] (external knowledge base; not shipped with the package).
+
+## Current product reality
+
+- Package: `skillbox@0.3.7` (Node CLI, canonical store under `~/.config/skillbox/`).
+- Golden workflow advertised: `list` → `status` → `update`.
+- Gaps make that workflow partially dishonest (see below).
+
+## Priority queue
+
+### P0 — Make `status` real for git skills
+
+**Problem:** `status` sets `trackable: true` for `source.type === "git"` but never fetches remote content. Git skills always appear up to date unless an error path is hit. `update` already refreshes git skills by fetching `SKILL.md` and rewriting the canonical tree.
+
+**Done when:**
+
+- [x] Git sources remote-check the same `SKILL.md` path resolution as `update`
+- [x] Outdated means remote SHA-256 ≠ local `checksum`
+- [x] Errors surface as `? name (message)` / JSON `error` without marking outdated
+- [x] Tests cover up-to-date, outdated, and missing-repo cases
+- [ ] PR merged
+
+**Approach:** content checksum of remote `SKILL.md` (aligned with `update` and URL status), not commit-SHA tracking from the original v1 plan text in `docs/plan.md`.
+
+### P1 — Resolve default-scope conflict
+
+**Problem:**
+
+| Source | Claim |
+| --- | --- |
+| `defaultConfig()` | `defaultScope: "user"` |
+| Config integration tests | expect `"user"` |
+| `resolveRuntime` nullish fallback | `?? "project"` |
+| `AGENTS.md` | default scope is `project` |
+
+**Done when:** one documented default, matching `defaultConfig`, runtime fallback, AGENTS.md, and tests.
+
+### P2 — Land or drop OpenCode Claude-compat path change
+
+**Problem:** Working tree (as of audit) removes OpenCode dual-write to `.claude/skills`; HEAD still dual-maps. Docs/paths may already match the narrower map while published code does not.
+
+**Done when:** code + `docs/paths.md` + release notes agree; either commit the removal or restore dual paths.
+
+### P3 — Copy-mode completeness
+
+**Problem:** `copyFiles` skips subdirectories. Nested skill assets are dropped under `installMode: "copy"` (Windows default).
+
+**Done when:** recursive copy **or** documented “flat skills only” with a test that locks the chosen behavior.
+
+### P4 — Install records vs filesystem success
+
+**Problem:** add flows record intended install paths even when symlink mode skips (e.g. EEXIST). Index can claim installs that are absent on disk.
+
+**Done when:** either only successful targets are recorded, or status/list clearly distinguish intended vs present installs.
+
+## Explicit non-priorities (for now)
+
+- Re-investigating historical add/update test flakes without a failing repro (audit: 101/101 green).
+- Public registry / marketplace.
+- Commit-hash-based git tracking until checksum-based status/update parity is solid.
+- Roadmap features not grounded in a decision or user request.
+
+## How to use this doc
+
+1. Pick the highest open P-item.
+2. Implement on a focused branch; keep unrelated working-tree edits out.
+3. Check the matching box under **Done when** when evidence lands.
+4. After merge, update this file (and the vault known-gaps page on the next vault ingest).
+
+## Changelog
+
+| Date | Note |
+| --- | --- |
+| 2026-08-06 | Masterplan created from implementation audit + known gaps. P0 started (git status remote check). |

--- a/docs/plan.md
+++ b/docs/plan.md
@@ -128,10 +128,12 @@ Each project entry includes:
 ## Update Detection
 
 - URL sources: hash remote content and compare to local checksum.
-- Git sources: store commit hash and compare to remote HEAD.
+- Git sources: fetch remote `SKILL.md` (same path resolution as `update`) and compare SHA-256 to the local checksum. Commit-hash tracking is deferred; see `docs/masterplan.md`.
 - Local-only sources: mark as manual (no update checks).
 
-Status always checks the network (no cache by default). A cache may be added later.
+Status always checks the network for trackable sources (no cache by default). A cache may be added later.
+
+Post-v1 priorities and open gaps live in `docs/masterplan.md`.
 
 ## Sync Strategy
 

--- a/src/commands/status.ts
+++ b/src/commands/status.ts
@@ -1,20 +1,9 @@
 import type { Command } from "commander";
 import { handleCommandError } from "../lib/command.js";
-import { fetchText } from "../lib/fetcher.js";
 import { loadIndex, saveIndex } from "../lib/index.js";
 import { isJsonEnabled, printInfo, printJson } from "../lib/output.js";
-import { hashContent } from "../lib/skill-store.js";
 import { groupAndSort, sortByName } from "../lib/source-grouping.js";
-
-type SkillStatus = {
-  name: string;
-  source: string;
-  trackable: boolean;
-  outdated: boolean;
-  localChecksum: string;
-  remoteChecksum?: string;
-  error?: string;
-};
+import { checkSkillStatus, type SkillStatus } from "../lib/status-check.js";
 
 type SourceGroup = {
   source: string;
@@ -23,48 +12,6 @@ type SourceGroup = {
   outdatedCount: number;
   upToDateCount: number;
 };
-
-async function checkSkillStatus(skill: {
-  name: string;
-  source: { type: string; url?: string };
-  checksum: string;
-}): Promise<SkillStatus> {
-  const isTrackable = skill.source.type === "url" || skill.source.type === "git";
-
-  if (!isTrackable || skill.source.type !== "url" || !skill.source.url) {
-    return {
-      name: skill.name,
-      source: skill.source.type,
-      trackable: isTrackable,
-      outdated: false,
-      localChecksum: skill.checksum,
-    };
-  }
-
-  try {
-    const remoteText = await fetchText(skill.source.url);
-    const remoteChecksum = hashContent(remoteText);
-    const outdated = remoteChecksum !== skill.checksum;
-
-    return {
-      name: skill.name,
-      source: skill.source.type,
-      trackable: true,
-      outdated,
-      localChecksum: skill.checksum,
-      remoteChecksum,
-    };
-  } catch (err) {
-    return {
-      name: skill.name,
-      source: skill.source.type,
-      trackable: true,
-      outdated: false,
-      localChecksum: skill.checksum,
-      error: err instanceof Error ? err.message : "Failed to check",
-    };
-  }
-}
 
 // Sort sources: url first, then git, then local (for status command - trackable first)
 const STATUS_SOURCE_ORDER = ["url", "git", "local"];

--- a/src/lib/status-check.ts
+++ b/src/lib/status-check.ts
@@ -1,0 +1,111 @@
+import { fetchText } from "./fetcher.js";
+import { fetchRepoFile, normalizeRepoRef } from "./repo-skills.js";
+import { hashContent } from "./skill-store.js";
+import type { IndexedSkill } from "./types.js";
+
+export type SkillStatus = {
+  name: string;
+  source: string;
+  trackable: boolean;
+  outdated: boolean;
+  localChecksum: string;
+  remoteChecksum?: string;
+  error?: string;
+};
+
+type StatusSkill = Pick<IndexedSkill, "name" | "source" | "checksum">;
+
+function baseStatus(
+  skill: StatusSkill,
+  overrides: Partial<SkillStatus> & Pick<SkillStatus, "trackable" | "outdated">
+): SkillStatus {
+  return {
+    name: skill.name,
+    source: skill.source.type,
+    localChecksum: skill.checksum,
+    ...overrides,
+  };
+}
+
+async function checkUrlSkill(skill: StatusSkill): Promise<SkillStatus> {
+  if (!skill.source.url) {
+    return baseStatus(skill, {
+      trackable: true,
+      outdated: false,
+      error: "Missing url on url-sourced skill",
+    });
+  }
+
+  try {
+    const remoteText = await fetchText(skill.source.url);
+    const remoteChecksum = hashContent(remoteText);
+    return baseStatus(skill, {
+      trackable: true,
+      outdated: remoteChecksum !== skill.checksum,
+      remoteChecksum,
+    });
+  } catch (err) {
+    return baseStatus(skill, {
+      trackable: true,
+      outdated: false,
+      error: err instanceof Error ? err.message : "Failed to check",
+    });
+  }
+}
+
+async function checkGitSkill(skill: StatusSkill): Promise<SkillStatus> {
+  if (!skill.source.repo) {
+    return baseStatus(skill, {
+      trackable: true,
+      outdated: false,
+      error: "Missing repo on git-sourced skill",
+    });
+  }
+
+  const [owner, repo] = skill.source.repo.split("/");
+  if (!owner || !repo) {
+    return baseStatus(skill, {
+      trackable: true,
+      outdated: false,
+      error: `Invalid git repo ref: ${skill.source.repo}`,
+    });
+  }
+
+  try {
+    const skillPath = skill.source.path?.replace(/\/$/, "") ?? "";
+    const ref = await normalizeRepoRef({
+      owner,
+      repo,
+      ref: skill.source.ref ?? "main",
+    });
+    const skillFilePath = skillPath ? `${skillPath}/SKILL.md` : "SKILL.md";
+    const markdown = await fetchRepoFile(ref, skillFilePath);
+    const remoteChecksum = hashContent(markdown);
+
+    return baseStatus(skill, {
+      trackable: true,
+      outdated: remoteChecksum !== skill.checksum,
+      remoteChecksum,
+    });
+  } catch (err) {
+    return baseStatus(skill, {
+      trackable: true,
+      outdated: false,
+      error: err instanceof Error ? err.message : "Failed to check",
+    });
+  }
+}
+
+export async function checkSkillStatus(skill: StatusSkill): Promise<SkillStatus> {
+  if (skill.source.type === "url") {
+    return checkUrlSkill(skill);
+  }
+  if (skill.source.type === "git") {
+    return checkGitSkill(skill);
+  }
+
+  return baseStatus(skill, {
+    trackable: false,
+    outdated: false,
+  });
+}

--- a/tests/integration/status.test.ts
+++ b/tests/integration/status.test.ts
@@ -83,4 +83,35 @@ describe("status command", () => {
       expect(localGroup?.trackable).toBe(false);
     });
   });
+
+  describe("with git skills missing repo metadata", () => {
+    beforeEach(async () => {
+      await testEnv.addSkillToIndex({
+        name: "git-missing-repo",
+        source: { type: "git" },
+        checksum: "stale",
+      });
+    });
+
+    it("marks git skills trackable and surfaces metadata errors", async () => {
+      const { result, data } = await runCliJson<{
+        data: {
+          skills: Array<{
+            name: string;
+            source: string;
+            trackable: boolean;
+            outdated: boolean;
+            error?: string;
+          }>;
+        };
+      }>(["status"]);
+
+      expect(result.exitCode).toBe(0);
+      const skill = data?.data.skills.find((entry) => entry.name === "git-missing-repo");
+      expect(skill?.source).toBe("git");
+      expect(skill?.trackable).toBe(true);
+      expect(skill?.outdated).toBe(false);
+      expect(skill?.error).toMatch(/Missing repo/i);
+    });
+  });
 });

--- a/tests/unit/status-check.test.ts
+++ b/tests/unit/status-check.test.ts
@@ -1,0 +1,173 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { hashContent } from "../../src/lib/skill-store.js";
+
+vi.mock("../../src/lib/fetcher.js", () => ({
+  fetchText: vi.fn(),
+}));
+
+vi.mock("../../src/lib/repo-skills.js", () => ({
+  normalizeRepoRef: vi.fn(),
+  fetchRepoFile: vi.fn(),
+}));
+
+import { fetchText } from "../../src/lib/fetcher.js";
+import { fetchRepoFile, normalizeRepoRef } from "../../src/lib/repo-skills.js";
+import { checkSkillStatus } from "../../src/lib/status-check.js";
+
+const fetchTextMock = vi.mocked(fetchText);
+const fetchRepoFileMock = vi.mocked(fetchRepoFile);
+const normalizeRepoRefMock = vi.mocked(normalizeRepoRef);
+
+const REMOTE_MARKDOWN = `---
+name: demo
+description: remote skill
+---
+
+# Demo
+`;
+
+describe("checkSkillStatus", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("marks local skills as not trackable", async () => {
+    const status = await checkSkillStatus({
+      name: "local-one",
+      source: { type: "local" },
+      checksum: "abc",
+    });
+
+    expect(status).toMatchObject({
+      name: "local-one",
+      source: "local",
+      trackable: false,
+      outdated: false,
+      localChecksum: "abc",
+    });
+    expect(status.remoteChecksum).toBeUndefined();
+  });
+
+  it("detects outdated url skills", async () => {
+    fetchTextMock.mockResolvedValue(REMOTE_MARKDOWN);
+
+    const status = await checkSkillStatus({
+      name: "url-one",
+      source: { type: "url", url: "https://example.com/SKILL.md" },
+      checksum: "stale-checksum",
+    });
+
+    expect(fetchTextMock).toHaveBeenCalledWith("https://example.com/SKILL.md");
+    expect(status.trackable).toBe(true);
+    expect(status.outdated).toBe(true);
+    expect(status.remoteChecksum).toBe(hashContent(REMOTE_MARKDOWN));
+    expect(status.error).toBeUndefined();
+  });
+
+  it("detects up-to-date url skills", async () => {
+    fetchTextMock.mockResolvedValue(REMOTE_MARKDOWN);
+    const checksum = hashContent(REMOTE_MARKDOWN);
+
+    const status = await checkSkillStatus({
+      name: "url-two",
+      source: { type: "url", url: "https://example.com/SKILL.md" },
+      checksum,
+    });
+
+    expect(status.outdated).toBe(false);
+    expect(status.remoteChecksum).toBe(checksum);
+  });
+
+  it("detects outdated git skills using the same SKILL.md path as update", async () => {
+    normalizeRepoRefMock.mockResolvedValue({
+      owner: "acme",
+      repo: "skills",
+      ref: "main",
+    });
+    fetchRepoFileMock.mockResolvedValue(REMOTE_MARKDOWN);
+
+    const status = await checkSkillStatus({
+      name: "git-one",
+      source: {
+        type: "git",
+        repo: "acme/skills",
+        path: "skills/git-one",
+        ref: "main",
+      },
+      checksum: "stale-checksum",
+    });
+
+    expect(normalizeRepoRefMock).toHaveBeenCalledWith({
+      owner: "acme",
+      repo: "skills",
+      ref: "main",
+    });
+    expect(fetchRepoFileMock).toHaveBeenCalledWith(
+      { owner: "acme", repo: "skills", ref: "main" },
+      "skills/git-one/SKILL.md"
+    );
+    expect(status).toMatchObject({
+      name: "git-one",
+      source: "git",
+      trackable: true,
+      outdated: true,
+      localChecksum: "stale-checksum",
+      remoteChecksum: hashContent(REMOTE_MARKDOWN),
+    });
+  });
+
+  it("detects up-to-date git skills", async () => {
+    const checksum = hashContent(REMOTE_MARKDOWN);
+    normalizeRepoRefMock.mockResolvedValue({
+      owner: "acme",
+      repo: "skills",
+      ref: "main",
+    });
+    fetchRepoFileMock.mockResolvedValue(REMOTE_MARKDOWN);
+
+    const status = await checkSkillStatus({
+      name: "git-two",
+      source: { type: "git", repo: "acme/skills", ref: "main" },
+      checksum,
+    });
+
+    expect(fetchRepoFileMock).toHaveBeenCalledWith(
+      { owner: "acme", repo: "skills", ref: "main" },
+      "SKILL.md"
+    );
+    expect(status.outdated).toBe(false);
+    expect(status.remoteChecksum).toBe(checksum);
+    expect(status.error).toBeUndefined();
+  });
+
+  it("returns an error for git skills missing repo metadata", async () => {
+    const status = await checkSkillStatus({
+      name: "git-broken",
+      source: { type: "git" },
+      checksum: "abc",
+    });
+
+    expect(status.trackable).toBe(true);
+    expect(status.outdated).toBe(false);
+    expect(status.error).toBe("Missing repo on git-sourced skill");
+    expect(normalizeRepoRefMock).not.toHaveBeenCalled();
+  });
+
+  it("surfaces fetch failures without marking outdated", async () => {
+    normalizeRepoRefMock.mockResolvedValue({
+      owner: "acme",
+      repo: "skills",
+      ref: "main",
+    });
+    fetchRepoFileMock.mockRejectedValue(new Error("Failed to fetch remote"));
+
+    const status = await checkSkillStatus({
+      name: "git-err",
+      source: { type: "git", repo: "acme/skills" },
+      checksum: "abc",
+    });
+
+    expect(status.outdated).toBe(false);
+    expect(status.error).toBe("Failed to fetch remote");
+  });
+});


### PR DESCRIPTION
## Summary

- Make `skillbox status` actually remote-check **git** skills (same `SKILL.md` path resolution as `update`, SHA-256 compare)
- Extract check logic to `src/lib/status-check.ts` with unit coverage
- Add `docs/masterplan.md` for the post-audit priority queue (P0–P4)

## Changes

- `src/lib/status-check.ts` — URL + git + local status checks
- `src/commands/status.ts` — thin command wrapper
- `tests/unit/status-check.test.ts` — up-to-date / outdated / missing-repo / fetch error
- `tests/integration/status.test.ts` — git metadata error path via CLI
- `docs/masterplan.md` — living backlog
- `docs/plan.md` — update-detection section aligned with checksum approach

## Flow

```mermaid
flowchart TD
  A[status] --> B{source.type}
  B -->|url| C[fetch URL text]
  B -->|git| D[normalizeRepoRef + fetchRepoFile SKILL.md]
  B -->|local| E[trackable false]
  C --> F[SHA-256 vs local checksum]
  D --> F
  F -->|mismatch| G[outdated]
  F -->|match| H[up to date]
  D -->|error| I[error, not outdated]
```

## Testing

- `npm run lint:ci`
- `npm run format`
- `npm run build`
- `npm test` — **109 passed** (was 101; +7 unit, +1 integration)

## Checklist

- [x] Self-reviewed code
- [x] Tests pass
- [x] Documentation updated

## AI-Generated Code

- Files modified with AI assistance: `src/lib/status-check.ts`, `src/commands/status.ts`, `tests/unit/status-check.test.ts`, `tests/integration/status.test.ts`, `docs/masterplan.md`, `docs/plan.md`
- All code was reviewed and validated before commit